### PR TITLE
Hotfixes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "*.convex.cloud",
       },
+      {
+        protocol: "https",
+        hostname: "*.harleyvan.com",
+      },
     ],
   },
 };


### PR DESCRIPTION
Update next.js config to allow images from self-hosted convex backend. 