### PR TITLE
Sprint6

### DIFF
--- a/src/app/(private)/dashboard/chat/[slug]/[threadId]/_client.tsx
+++ b/src/app/(private)/dashboard/chat/[slug]/[threadId]/_client.tsx
@@ -31,7 +31,10 @@ export function ChatThreadClient({
   }
 
   return (
-    <div className="flex h-full overflow-hidden min-h-0 relative">
+    <div
+      className="relative flex overflow-hidden"
+      style={{ height: "100dvh" }}
+    >
       <div className="flex flex-col flex-1 min-w-0 min-h-0">
         <div className="flex-1 min-h-0 bg-background">
           <ChatInterface

--- a/src/app/(private)/dashboard/layout.tsx
+++ b/src/app/(private)/dashboard/layout.tsx
@@ -15,7 +15,7 @@ export default async function DashBoardLayout({
       <SidebarProvider className="flex h-screen">
         <AppSidebar preloadedProfile={preloadedProfile} />
         <SidebarInset className="flex flex-col h-full overflow-hidden">
-          <div className="flex h-full min-h-0 flex-1 flex-col overflow-y-auto pb-safe">
+          <div className="flex h-full min-h-0 flex-1 flex-col overflow-y-auto">
             {children}
           </div>
         </SidebarInset>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -193,22 +193,6 @@
   }
 }
 
-@utility pb-safe {
-  padding-bottom: env(safe-area-inset-bottom);
-}
-
-@utility pt-safe {
-  padding-top: env(safe-area-inset-top);
-}
-
-@utility pl-safe {
-  padding-left: env(safe-area-inset-left);
-}
-
-@utility pr-safe {
-  padding-right: env(safe-area-inset-right);
-}
-
 /* ── Usage table live indicator animations ───────────────────────────────── */
 @keyframes dotPulse {
   0%,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Viewport } from "next";
+import type { Metadata } from "next";
 import { Roboto_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
@@ -9,10 +9,6 @@ const robotoMono = Roboto_Mono({
   subsets: ["latin"],
   variable: "--font-mono",
 });
-
-export const viewport: Viewport = {
-  viewportFit: "cover",
-};
 
 export const metadata: Metadata = {
   title: "IskoLab | Fablab UP Cebu",

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Loader2, Send, User, Hash, ArrowLeft } from "lucide-react";
 import Link from "next/link";
 
@@ -27,6 +27,18 @@ const AVATAR_COLORS = [
   "#534AB7",
   "#0FA896",
 ];
+
+function getVisualViewportBottomInset() {
+  if (typeof window === "undefined") return 0;
+
+  const viewport = window.visualViewport;
+  if (!viewport) return 0;
+
+  return Math.max(
+    0,
+    window.innerHeight - viewport.height - viewport.offsetTop,
+  );
+}
 
 function getAvatarColor(name: string): string {
   let hash = 0;
@@ -73,6 +85,7 @@ export function ChatInterface({
   showBackButton,
 }: ChatInterfaceProps) {
   const [showTimeId, setShowTimeId] = useState<string | null>(null);
+  const [composerViewportInset, setComposerViewportInset] = useState(0);
 
   const {
     input,
@@ -96,9 +109,28 @@ export function ChatInterface({
     removeAttachment,
   } = useChat({ roomId, threadId });
 
+  useEffect(() => {
+    const syncComposerInset = () => {
+      setComposerViewportInset(getVisualViewportBottomInset());
+    };
+
+    syncComposerInset();
+
+    const viewport = window.visualViewport;
+    window.addEventListener("resize", syncComposerInset);
+    viewport?.addEventListener("resize", syncComposerInset);
+    viewport?.addEventListener("scroll", syncComposerInset);
+
+    return () => {
+      window.removeEventListener("resize", syncComposerInset);
+      viewport?.removeEventListener("resize", syncComposerInset);
+      viewport?.removeEventListener("scroll", syncComposerInset);
+    };
+  }, []);
+
   return (
     <div
-      className="flex flex-col h-full relative overflow-hidden"
+      className="relative flex h-full min-h-0 flex-col overflow-hidden"
       style={{ background: "var(--fab-bg-main)" }}
     >
       {/* ── Sticky channel header ────────────────────────────────────────── */}
@@ -155,6 +187,10 @@ export function ChatInterface({
       <div
         ref={scrollContainerRef}
         className="flex-1 overflow-y-auto px-4 py-4 relative z-2"
+        style={{
+          WebkitOverflowScrolling: "touch",
+          overscrollBehavior: "contain",
+        }}
       >
         {isLoading ? (
           <ChatMessagesSkeletonList />
@@ -561,12 +597,13 @@ export function ChatInterface({
       {/* Input area — sticky bottom                                          */}
       {/* ------------------------------------------------------------------ */}
       <div
-        className="sticky bottom-0 z-10 px-4 pb-4 pt-2 shrink-0"
+        className="sticky bottom-0 z-10 px-4 pt-2 shrink-0"
         style={{
           background: "rgba(250,249,255,0.92)",
           backdropFilter: "blur(10px)",
           WebkitBackdropFilter: "blur(10px)",
           borderTop: "1px solid var(--fab-border)",
+          paddingBottom: `calc(env(safe-area-inset-bottom) + 1rem + ${composerViewportInset}px)`,
         }}
       >
         {/* ── Pending attachments ───────────────────────────────────────── */}

--- a/src/components/chat/chat-loading.tsx
+++ b/src/components/chat/chat-loading.tsx
@@ -156,12 +156,13 @@ export function ChatHeaderSkeleton() {
 export function ChatInputSkeleton() {
   return (
     <div
-      className="sticky bottom-0 z-10 px-4 pb-4 pt-2 shrink-0"
+      className="sticky bottom-0 z-10 px-4 pt-2 shrink-0"
       style={{
         background: "rgba(250,249,255,0.92)",
         backdropFilter: "blur(10px)",
         WebkitBackdropFilter: "blur(10px)",
         borderTop: "1px solid var(--fab-border)",
+        paddingBottom: "calc(env(safe-area-inset-bottom) + 1rem)",
       }}
     >
       <div
@@ -213,8 +214,8 @@ export function ChatInputSkeleton() {
 export function ChatThreadLoading() {
   return (
     <div
-      className="relative flex h-full min-h-0 flex-col overflow-hidden"
-      style={{ background: "var(--fab-bg-main)" }}
+      className="relative flex min-h-0 flex-col overflow-hidden"
+      style={{ background: "var(--fab-bg-main)", height: "100dvh" }}
     >
       <ChatHeaderSkeleton />
 
@@ -232,7 +233,13 @@ export function ChatThreadLoading() {
       />
 
       {/* Messages area */}
-      <div className="relative z-[1] flex-1 overflow-y-auto px-4 py-4">
+      <div
+        className="relative z-[1] flex-1 overflow-y-auto px-4 py-4"
+        style={{
+          WebkitOverflowScrolling: "touch",
+          overscrollBehavior: "contain",
+        }}
+      >
         <ChatMessagesSkeletonList />
       </div>
 

--- a/src/components/public-mobile-nav-card.tsx
+++ b/src/components/public-mobile-nav-card.tsx
@@ -124,7 +124,7 @@ export function PublicMobileNavCard({ items }: PublicMobileNavCardProps) {
 
   return (
     <div ref={rootRef} className="pointer-events-auto sm:hidden">
-      <div className="relative z-[210] flex items-center justify-end">
+      <div className="relative z-20 flex items-center justify-end">
         <button
           type="button"
           aria-expanded={open}
@@ -163,7 +163,7 @@ export function PublicMobileNavCard({ items }: PublicMobileNavCardProps) {
 
       <div
         className={cn(
-          "fixed inset-0 z-[190] sm:hidden",
+          "fixed inset-0 z-10 sm:hidden",
           open ? "pointer-events-auto" : "pointer-events-none",
         )}
         aria-hidden={!open}

--- a/src/components/public-navbar.tsx
+++ b/src/components/public-navbar.tsx
@@ -25,7 +25,7 @@ const desktopNavLinkClass =
 
 export function PublicNavbar() {
   return (
-    <header className="fixed top-0 left-0 z-[200] h-20 w-full sm:sticky sm:h-16 sm:border-b sm:border-black sm:bg-background sm:shadow-none sm:backdrop-blur-none">
+    <header className="fixed top-0 left-0 z-40 h-20 w-full sm:sticky sm:h-16 sm:border-b sm:border-black sm:bg-background sm:shadow-none sm:backdrop-blur-none">
       <div className="mx-auto flex h-full max-w-full items-center justify-between px-4 sm:px-10 lg:px-16">
         <div className="flex items-center gap-3">
           <Link

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -39,7 +39,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-[300] bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-50 bg-black/80 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className,
       )}
       {...props}
@@ -61,7 +61,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-[300] grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-4xl bg-background p-6 text-sm ring-1 ring-foreground/5 duration-100 outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-4xl bg-background p-6 text-sm ring-1 ring-foreground/5 duration-100 outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -198,7 +198,7 @@ function Sidebar({
             <SheetTitle>Sidebar</SheetTitle>
             <SheetDescription>Displays the mobile sidebar.</SheetDescription>
           </SheetHeader>
-          <div className="flex h-full w-full flex-col pb-safe">{children}</div>
+          <div className="flex h-full w-full flex-col">{children}</div>
         </SheetContent>
       </Sheet>
     );
@@ -347,7 +347,7 @@ function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="sidebar-footer"
       data-sidebar="footer"
-      className={cn("gap-2 p-2 pb-safe flex flex-col", className)}
+      className={cn("gap-2 p-2 flex flex-col", className)}
       {...props}
     />
   );


### PR DESCRIPTION
This pull request focuses on improving mobile and viewport handling, particularly for chat and layout components, and cleans up legacy CSS utilities for safe area insets. It also standardizes z-index values across various UI layers to ensure consistent stacking order. The most significant changes are grouped below:

**Mobile viewport and safe area handling:**

* Removed custom CSS utility classes for safe area insets (like `pb-safe`, `pt-safe`, etc.) from `globals.css` and replaced them with direct use of `env(safe-area-inset-*)` in inline styles where needed.
* Updated chat interface components to dynamically calculate and apply bottom insets using the Visual Viewport API, ensuring proper spacing for input areas on mobile devices. [[1]](diffhunk://#diff-90e31998ff9dd31bd4ab0a6ede8355f4f9854d562f088b24f49e784c761d12edR31-R42) [[2]](diffhunk://#diff-90e31998ff9dd31bd4ab0a6ede8355f4f9854d562f088b24f49e784c761d12edR88) [[3]](diffhunk://#diff-90e31998ff9dd31bd4ab0a6ede8355f4f9854d562f088b24f49e784c761d12edR112-R133) [[4]](diffhunk://#diff-90e31998ff9dd31bd4ab0a6ede8355f4f9854d562f088b24f49e784c761d12edL564-R606) [[5]](diffhunk://#diff-db9cb249bd1be25eb52e9f83a05a192c119be90c65dd163270f201c078c6a220L159-R165)

**Layout and height adjustments:**

* Switched from fixed `h-screen`/`h-full` usage to `height: 100dvh` in key containers to better handle mobile browser UI and dynamic viewport heights. ([src/app/(private)/dashboard/chat/[slug]/[threadId]/_client.tsxL34-R37](diffhunk://#diff-bd747ce374c30e285dcfdc855adacb12ed7a608319994ab15aab0086f4cb21cbL34-R37), [src/components/chat/chat-loading.tsxL216-R218](diffhunk://#diff-db9cb249bd1be25eb52e9f83a05a192c119be90c65dd163270f201c078c6a220L216-R218))

**Z-index and stacking context consistency:**

* Standardized z-index values for navigation bars, dialogs, overlays, and mobile nav cards to improve layering and prevent overlap issues. [[1]](diffhunk://#diff-acf508510780910a8dd1166547797937b8ee5cdc4f01e10325e70c322beb9c83L127-R127) [[2]](diffhunk://#diff-acf508510780910a8dd1166547797937b8ee5cdc4f01e10325e70c322beb9c83L166-R166) [[3]](diffhunk://#diff-7c1da056cc33ca7e4a7c60afbf2e7df285b3558f5a81b7096f5e31a4b1871287L28-R28) [[4]](diffhunk://#diff-c24ba5eb166e594867718acf90dc35aebf9bfd7c453770647225547d11b4f89dL42-R42) [[5]](diffhunk://#diff-c24ba5eb166e594867718acf90dc35aebf9bfd7c453770647225547d11b4f89dL64-R64)

**Code and import cleanup:**

* Removed unused `Viewport` import and related `viewport` export from `layout.tsx`, as safe area handling is now managed inline. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L1-R1) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L13-L16)

**Component and style refinements:**

* Applied `WebkitOverflowScrolling: "touch"` and `overscrollBehavior: "contain"` to chat message containers for smoother mobile scrolling. [[1]](diffhunk://#diff-90e31998ff9dd31bd4ab0a6ede8355f4f9854d562f088b24f49e784c761d12edR190-R193) [[2]](diffhunk://#diff-db9cb249bd1be25eb52e9f83a05a192c119be90c65dd163270f201c078c6a220L235-R242)
* Cleaned up sidebar and footer components to remove reliance on deprecated safe area utility classes. [[1]](diffhunk://#diff-dc267fc83481d6e45eb6d8382bcdc52460e7b211f270fbf46d24862014acaacaL201-R201) [[2]](diffhunk://#diff-dc267fc83481d6e45eb6d8382bcdc52460e7b211f270fbf46d24862014acaacaL350-R350)