### PR TITLE
Sprint6.5 fixes

### DIFF
--- a/convex/calendar/helper.ts
+++ b/convex/calendar/helper.ts
@@ -1,3 +1,4 @@
+import { UserRole } from "../constants";
 import type {
   CalendarBookingItem,
   CalendarFrameData,
@@ -18,7 +19,7 @@ export type CalendarBookingRange = {
 };
 
 function isPrivilegedRole(role: CalendarRole) {
-  return role === "admin" || role === "maker";
+  return role === UserRole.ADMIN || role === UserRole.MAKER;
 }
 
 function canSeeCalendarUsageDetails(args: {
@@ -26,7 +27,9 @@ function canSeeCalendarUsageDetails(args: {
   ownedProjectIds: Set<Id<"projects">>;
   projectId: Id<"projects">;
 }) {
-  return args.role !== "client" || args.ownedProjectIds.has(args.projectId);
+  return (
+    args.role !== UserRole.CLIENT || args.ownedProjectIds.has(args.projectId)
+  );
 }
 
 function mapCalendarFrameService(service: Doc<"services">) {
@@ -85,7 +88,7 @@ async function loadCandidateUsages(
 }
 
 async function loadOwnedProjectIds(ctx: CalendarQueryContext) {
-  if (ctx.profile.role === "client") {
+  if (ctx.profile.role === UserRole.CLIENT) {
     const projects = await ctx.db
       .query("projects")
       .withIndex("by_userProfile", (q) => q.eq("userId", ctx.profile._id))
@@ -94,7 +97,7 @@ async function loadOwnedProjectIds(ctx: CalendarQueryContext) {
     return new Set(projects.map((project) => project._id));
   }
 
-  if (ctx.profile.role === "maker") {
+  if (ctx.profile.role === UserRole.MAKER) {
     const projects = await ctx.db
       .query("projects")
       .withIndex("by_assignedMaker", (q) =>
@@ -257,7 +260,7 @@ async function loadCandidateServiceProjects(
   //   - Maker  → only assigned projects (via ownedProjectIds)
   //   - Client → only own projects (via ownedProjectIds)
   const visibleProjects = candidateProjects.filter((project) => {
-    if (ctx.profile.role === "admin") return true;
+    if (ctx.profile.role === UserRole.ADMIN) return true;
     return ownedProjectIds.has(project._id);
   });
 

--- a/convex/calendar/helper.ts
+++ b/convex/calendar/helper.ts
@@ -85,16 +85,29 @@ async function loadCandidateUsages(
 }
 
 async function loadOwnedProjectIds(ctx: CalendarQueryContext) {
-  if (ctx.profile.role !== "client") {
-    return new Set<Id<"projects">>();
+  if (ctx.profile.role === "client") {
+    const projects = await ctx.db
+      .query("projects")
+      .withIndex("by_userProfile", (q) => q.eq("userId", ctx.profile._id))
+      .collect();
+
+    return new Set(projects.map((project) => project._id));
   }
 
-  const projects = await ctx.db
-    .query("projects")
-    .withIndex("by_userProfile", (q) => q.eq("userId", ctx.profile._id))
-    .collect();
+  if (ctx.profile.role === "maker") {
+    const projects = await ctx.db
+      .query("projects")
+      .withIndex("by_assignedMaker", (q) =>
+        q.eq("assignedMaker", ctx.profile._id),
+      )
+      .collect();
 
-  return new Set(projects.map((project) => project._id));
+    return new Set(projects.map((project) => project._id));
+  }
+
+  // Admin sees everything — return empty set so canSeeCalendarUsageDetails
+  // treats all bookings as visible.
+  return new Set<Id<"projects">>();
 }
 
 function collectVisibleProjectIds(args: {

--- a/convex/calendar/helper.ts
+++ b/convex/calendar/helper.ts
@@ -242,7 +242,6 @@ async function loadCandidateServiceProjects(
   range: CalendarBookingRange,
 ) {
   const ownedProjectIds = await loadOwnedProjectIds(ctx);
-  const isPrivileged = isPrivilegedRole(ctx.profile.role);
 
   const candidateProjects = await ctx.db
     .query("projects")
@@ -253,9 +252,12 @@ async function loadCandidateServiceProjects(
     )
     .collect();
 
-  // Apply access filter
+  // Apply access filter:
+  //   - Admin  → full access (sees all)
+  //   - Maker  → only assigned projects (via ownedProjectIds)
+  //   - Client → only own projects (via ownedProjectIds)
   const visibleProjects = candidateProjects.filter((project) => {
-    if (isPrivileged) return true;
+    if (ctx.profile.role === "admin") return true;
     return ownedProjectIds.has(project._id);
   });
 

--- a/convex/chat/query.ts
+++ b/convex/chat/query.ts
@@ -2,6 +2,9 @@ import { paginationOptsValidator } from "convex/server";
 import { authQuery } from "../helper";
 import { checkRoomMembership } from "./helper";
 import { v } from "convex/values";
+import { PROJECT_ARCHIVE_STATUSES } from "../constants";
+
+const ARCHIVE_STATUSES = new Set(PROJECT_ARCHIVE_STATUSES);
 
 export const getRoom = authQuery({
   args: { roomId: v.id("rooms") },
@@ -218,5 +221,28 @@ export const getAddableUsers = authQuery({
     const allUsers = await ctx.db.query("userProfile").collect();
 
     return allUsers.filter((u) => !memberIds.has(u._id));
+  },
+});
+
+// ── Thread archival banner info ──────────────────────────────────────────────
+// Returns the project status if the thread belongs to a project that has reached
+// a terminal state and is pending archival (thread not yet archived).
+
+export const getThreadProjectStatus = authQuery({
+  args: { threadId: v.id("threads") },
+  handler: async (ctx, args) => {
+    const thread = await ctx.db.get(args.threadId);
+    if (!thread?.projectId) return null;
+
+    const project = await ctx.db.get(thread.projectId);
+    if (!project) return null;
+
+    if (thread.archived === "Archived") return null;
+    if (!ARCHIVE_STATUSES.has(project.status)) return null;
+
+    return {
+      status: project.status,
+      archivalDeadline: project.archivalDeadline ?? null,
+    };
   },
 });

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -265,6 +265,13 @@ export const PROJECT_STATUS_LABELS: Record<ProjectStatusType, string> = {
   cancelled: "Cancelled",
 };
 
+/** Statuses that trigger thread archival when reached. */
+export const PROJECT_ARCHIVE_STATUSES: readonly ProjectStatusType[] = [
+  ProjectStatus.CANCELLED,
+  ProjectStatus.REJECTED,
+  ProjectStatus.CLAIMED,
+] as const;
+
 export const PROJECT_STATUS_TRANSITIONS: Record<
   ProjectStatusType,
   readonly ProjectStatusType[]

--- a/convex/projects/helper.ts
+++ b/convex/projects/helper.ts
@@ -12,6 +12,7 @@ import {
 import {
   FILE_CATEGORIES,
   MaterialStatus,
+  PROJECT_ARCHIVE_STATUSES,
   PROJECT_STATUS_LABELS,
   PROJECT_STATUS_TRANSITIONS,
   UserRole,
@@ -841,6 +842,48 @@ export async function applyStatusChange(
     await syncProjectTotalInvoice(ctx, project._id);
   }
 
+  // ── Unschedule / schedule on terminal status transitions ──────────────
+  const wasArchiveStatus = PROJECT_ARCHIVE_STATUSES.includes(
+    existingProject.status as ProjectStatusType,
+  );
+  const isArchiveStatus = PROJECT_ARCHIVE_STATUSES.includes(
+    status as ProjectStatusType,
+  );
+
+  if (wasArchiveStatus && !isArchiveStatus) {
+    // Project left a terminal state — clear the scheduled deadline
+    await ctx.db.patch(project._id, { archivalDeadline: undefined });
+  } else if (isArchiveStatus) {
+    // Project entered a terminal state — schedule archival
+    const thread = await ctx.db
+      .query("threads")
+      .withIndex("projectId", (q) => q.eq("projectId", project._id))
+      .first();
+
+    if (thread && thread.archived !== "Archived") {
+      const now = getCurrentTimestamp();
+      const deadline = now + 86_400_000;
+
+      const dateStr = formatLabDate(deadline, {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      });
+
+      lines.push(`- This thread will be archived on **${dateStr}**`);
+
+      // Store the deadline so the frontend can show when archival happens
+      await ctx.db.patch(project._id, { archivalDeadline: deadline });
+
+      await ctx.scheduler.runAfter(
+        86_400_000,
+        internal.projects.mutate.archiveProjectThread,
+        { projectId: project._id },
+      );
+    }
+  }
+
   return lines;
 }
 
@@ -905,6 +948,51 @@ export async function removeRoomMember(
   }
 }
 
+/**
+ * Check if a maker is still assigned to any other project that shares the
+ * given chat room. Prevents removing a maker from a room they should still
+ * have access to.
+ */
+async function isMakerAssignedToOtherProjectInRoom(
+  ctx: Pick<MutationCtx, "db">,
+  roomId: Id<"rooms">,
+  excludeProjectId: Id<"projects">,
+  makerId: Id<"userProfile">,
+): Promise<boolean> {
+  const threads = await ctx.db
+    .query("threads")
+    .withIndex("by_roomId", (q) => q.eq("roomId", roomId))
+    .collect();
+
+  const otherProjectIds = threads
+    .map((t) => t.projectId)
+    .filter(
+      (pid): pid is Id<"projects"> =>
+        pid !== undefined && pid !== excludeProjectId,
+    );
+
+  if (otherProjectIds.length === 0) return false;
+
+  const otherProjects = await Promise.all(
+    otherProjectIds.map((pid) => ctx.db.get(pid)),
+  );
+
+  return otherProjects.some((p) => p?.assignedMaker === makerId);
+}
+
+/**
+ * Assigns or unassigns a maker for a project.
+ *
+ * When **assigning** (`makerId` is a valid user ID): patches the project's
+ * `assignedMaker`, adds the new maker to the project's chat room, and removes
+ * the previous maker (if any) — unless they're still needed for another project
+ * in the same room.
+ *
+ * When **unassigning** (`makerId` is `null`): clears `assignedMaker` and removes
+ * the maker from the chat room (subject to the same multi-project guard).
+ *
+ * Returns change-log lines for the system message.
+ */
 export async function applyMakerAssignment(
   ctx: MutationCtx,
   project: Doc<"projects">,
@@ -919,7 +1007,16 @@ export async function applyMakerAssignment(
 
     const roomId = await findProjectRoom(ctx, project._id);
     if (roomId) {
-      await removeRoomMember(ctx, roomId, project.assignedMaker);
+      // Only remove from room if they aren't assigned to another project in it
+      const stillNeeded = await isMakerAssignedToOtherProjectInRoom(
+        ctx,
+        roomId,
+        project._id,
+        project.assignedMaker,
+      );
+      if (!stillNeeded) {
+        await removeRoomMember(ctx, roomId, project.assignedMaker);
+      }
     }
 
     // Patch with undefined to clear the optional field
@@ -941,11 +1038,20 @@ export async function applyMakerAssignment(
   const roomId = await findProjectRoom(ctx, project._id);
 
   // If there was a previous maker who is being replaced, remove them from the room
+  // but only if they aren't assigned to another project that shares the same room.
   if (project.assignedMaker) {
     if (roomId) {
-      await removeRoomMember(ctx, roomId, project.assignedMaker);
+      const stillNeeded = await isMakerAssignedToOtherProjectInRoom(
+        ctx,
+        roomId,
+        project._id,
+        project.assignedMaker,
+      );
+      if (!stillNeeded) {
+        await removeRoomMember(ctx, roomId, project.assignedMaker);
+        messages.push(`- Previous maker removed from project chat room`);
+      }
     }
-    messages.push(`- Previous maker removed from project chat room`);
   }
 
   // Add the new maker to the project's chat room

--- a/convex/projects/helper.ts
+++ b/convex/projects/helper.ts
@@ -14,6 +14,7 @@ import {
   MaterialStatus,
   PROJECT_STATUS_LABELS,
   PROJECT_STATUS_TRANSITIONS,
+  UserRole,
   type MaterialStatusType,
   type ProjectStatusType,
 } from "../constants";
@@ -907,16 +908,34 @@ export async function removeRoomMember(
 export async function applyMakerAssignment(
   ctx: MutationCtx,
   project: Doc<"projects">,
-  makerId: Id<"userProfile">,
+  makerId: Id<"userProfile"> | null,
 ): Promise<string[]> {
+  const messages: string[] = [];
+
+  // ── Unassignment path ─────────────────────────────────────────────────────
+  if (makerId === null) {
+    // Already unassigned — nothing to do
+    if (!project.assignedMaker) return [];
+
+    const roomId = await findProjectRoom(ctx, project._id);
+    if (roomId) {
+      await removeRoomMember(ctx, roomId, project.assignedMaker);
+    }
+
+    // Patch with undefined to clear the optional field
+    await ctx.db.patch(project._id, { assignedMaker: undefined });
+
+    messages.push(`- Maker unassigned from project`);
+    return messages;
+  }
+
+  // ── Assignment / reassignment path ────────────────────────────────────────
   const makerProfile = await ctx.db.get(makerId);
-  if (!makerProfile || makerProfile.role !== "maker") {
+  if (!makerProfile || makerProfile.role !== UserRole.MAKER) {
     throw new ConvexError("Assigned user must be a maker");
   }
 
   if (project.assignedMaker === makerId) return [];
-
-  const messages: string[] = [];
 
   // Find the project room once — both removal and addition use the same room
   const roomId = await findProjectRoom(ctx, project._id);

--- a/convex/projects/helper.ts
+++ b/convex/projects/helper.ts
@@ -847,6 +847,63 @@ export async function applyStatusChange(
  * Assigns a maker to the project record and its resource usage record.
  * Returns change-log lines for the system message.
  */
+// ── Chat room membership helpers ────────────────────────────────────────────
+
+/**
+ * Find the chat room associated with a project, if any.
+ * Projects link to rooms via the threads table (threads.projectId → threads.roomId).
+ */
+async function findProjectRoom(
+  ctx: Pick<MutationCtx, "db">,
+  projectId: Id<"projects">,
+): Promise<Id<"rooms"> | null> {
+  const thread = await ctx.db
+    .query("threads")
+    .withIndex("projectId", (q) => q.eq("projectId", projectId))
+    .first();
+  return thread?.roomId ?? null;
+}
+
+/**
+ * Add a user to a room if they aren't already a member.
+ */
+export async function addRoomMember(
+  ctx: Pick<MutationCtx, "db">,
+  roomId: Id<"rooms">,
+  participantId: Id<"userProfile">,
+): Promise<void> {
+  const existing = await ctx.db
+    .query("roomMembers")
+    .withIndex("by_roomId_participantId", (q) =>
+      q.eq("roomId", roomId).eq("participantId", participantId),
+    )
+    .first();
+
+  if (!existing) {
+    await ctx.db.insert("roomMembers", { roomId, participantId });
+  }
+}
+
+/**
+ * Remove a user from a room if they are a member.
+ */
+export async function removeRoomMember(
+  ctx: Pick<MutationCtx, "db">,
+  roomId: Id<"rooms">,
+  participantId: Id<"userProfile">,
+): Promise<void> {
+  const existing = await ctx.db
+    .query("roomMembers")
+    .withIndex("by_roomId_participantId", (q) =>
+      q.eq("roomId", roomId).eq("participantId", participantId),
+    )
+    .first();
+
+  if (existing) {
+    await ctx.db.delete(existing._id);
+  }
+}
+
 export async function applyMakerAssignment(
   ctx: MutationCtx,
   project: Doc<"projects">,
@@ -859,9 +916,29 @@ export async function applyMakerAssignment(
 
   if (project.assignedMaker === makerId) return [];
 
+  const messages: string[] = [];
+
+  // Find the project room once — both removal and addition use the same room
+  const roomId = await findProjectRoom(ctx, project._id);
+
+  // If there was a previous maker who is being replaced, remove them from the room
+  if (project.assignedMaker) {
+    if (roomId) {
+      await removeRoomMember(ctx, roomId, project.assignedMaker);
+    }
+    messages.push(`- Previous maker removed from project chat room`);
+  }
+
+  // Add the new maker to the project's chat room
+  if (roomId) {
+    await addRoomMember(ctx, roomId, makerId);
+  }
+
   await ctx.db.patch(project._id, { assignedMaker: makerId });
 
-  return [`- Assigned maker updated to: **${makerProfile.name}**`];
+  messages.push(`- Assigned maker updated to: **${makerProfile.name}**`);
+
+  return messages;
 }
 
 export async function syncMaterialUsageStock(

--- a/convex/projects/mutate.ts
+++ b/convex/projects/mutate.ts
@@ -747,7 +747,11 @@ export const markProjectPaid = authMutation({
   handler: async (ctx, args) => {
     const project = await ctx.db.get(args.projectId);
     if (!project) throw new ConvexError("Project not found.");
-    if (project.status !== "completed" && project.status !== "paid") {
+    if (
+      project.status !== "completed" &&
+      project.status !== "paid" &&
+      project.status !== "claimed"
+    ) {
       throw new ConvexError(
         "Only completed or paid projects can have payment details set.",
       );

--- a/convex/projects/mutate.ts
+++ b/convex/projects/mutate.ts
@@ -266,7 +266,10 @@ export const updateProject = authMutation({
       ),
     ),
     // Assignments
-    makerId: v.optional(v.id("userProfile")),
+    //   - valid ID → assign/reassign that maker
+    //   - null     → unassign the current maker
+    //   - undefined → no change
+    makerId: v.optional(v.union(v.id("userProfile"), v.null())),
   },
   handler: async (ctx, args) => {
     const existingProject = await ctx.db.get(args.projectId);

--- a/convex/projects/mutate.ts
+++ b/convex/projects/mutate.ts
@@ -31,6 +31,7 @@ import {
   sendProjectSystemMessage,
   applyStatusChange,
   applyMakerAssignment,
+  addRoomMember,
   syncMaterialUsageStock,
   buildMaterialSnapshot,
   scheduleProjectUpdateEmail,
@@ -231,7 +232,12 @@ export const createProject = authMutation({
       now,
     );
 
-    // ── 10. Claim uploaded files ──────────────────────────────────────────────
+    // ── 10. If a maker was pre-assigned, add them to the chat room ────────────
+    if (args.assignedMaker) {
+      await addRoomMember(ctx, roomId, args.assignedMaker);
+    }
+
+    // ── 11. Claim uploaded files ──────────────────────────────────────────────
     if (args.files && args.files.length > 0) {
       claimFiles(ctx, args.files);
     }

--- a/convex/projects/mutate.ts
+++ b/convex/projects/mutate.ts
@@ -1,13 +1,13 @@
 import { v, ConvexError } from "convex/values";
 import { authMutation, checkAuthority, claimFiles } from "../helper";
 import { Id } from "../_generated/dataModel";
-import { MutationCtx } from "../_generated/server";
+import { internalMutation, MutationCtx } from "../_generated/server";
 import {
   formatLabDate,
   formatLabTime,
+  getCurrentTimestamp,
   getLabDayStartTimestamp,
 } from "../../src/lib/lab-time";
-
 import {
   BookingWindow,
   ProjectStatus,
@@ -917,5 +917,50 @@ export const updateOwnProjectDetails = authMutation({
     await sendProjectSystemMessage(ctx, args.projectId, [
       `${actorLabel} updated: ${changed.join(", ")}.`,
     ]);
+  },
+});
+
+// ── Scheduled archival ───────────────────────────────────────────────────────
+// Called by ctx.scheduler.runAfter from applyStatusChange when a project reaches
+// a terminal status. Sends a final system message then archives the thread.
+
+export const archiveProjectThread = internalMutation({
+  args: {
+    projectId: v.id("projects"),
+  },
+  handler: async (ctx, args) => {
+    const project = await ctx.db.get(args.projectId);
+    // Don't archive if the project no longer exists or has left the terminal state
+    if (!project) return;
+
+    const isTerminal =
+      project.status === "cancelled" ||
+      project.status === "rejected" ||
+      project.status === "claimed";
+    if (!isTerminal) return;
+
+    const thread = await ctx.db
+      .query("threads")
+      .withIndex("projectId", (q) => q.eq("projectId", args.projectId))
+      .first();
+
+    if (!thread || thread.archived === "Archived") return;
+
+    await ctx.db.patch(thread._id, { archived: "Archived" });
+
+    // Send a final system message confirming archival
+    const content = "This thread has been archived.";
+    const now = getCurrentTimestamp();
+    await ctx.db.insert("messages", {
+      room: thread.roomId,
+      threadId: thread._id,
+      content,
+      sender: "System",
+    });
+    await ctx.db.patch(thread._id, {
+      lastMessageText: content,
+      lastMessageAt: now,
+      messageCount: (thread.messageCount ?? 0) + 1,
+    });
   },
 });

--- a/convex/projects/query.ts
+++ b/convex/projects/query.ts
@@ -319,6 +319,7 @@ export const getProject = authQuery({
           _id: serviceDoc._id,
           name: serviceDoc.name,
           status: serviceDoc.status,
+          resources: serviceDoc.resources,
           serviceCategory: serviceDoc.serviceCategory,
         }
       : null;

--- a/convex/projects/query.ts
+++ b/convex/projects/query.ts
@@ -111,10 +111,12 @@ export const getProjects = authQuery({
     dateFilter: v.optional(v.string()),
     sortBy: v.optional(v.string()),
     searchText: v.optional(v.string()),
+    assignedToMe: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const { role, _id: callerId } = ctx.profile;
     const isPrivileged = role === "admin" || role === "maker";
+    const filterByAssignedMaker = args.assignedToMe === true;
 
     const hasStatusFilter =
       args.statusFilter !== undefined && args.statusFilter !== "all";
@@ -133,6 +135,12 @@ export const getProjects = authQuery({
       if (!isPrivileged) {
         searchQuery = searchQuery.filter((q) =>
           q.eq(q.field("userId"), callerId),
+        );
+      }
+
+      if (filterByAssignedMaker) {
+        searchQuery = searchQuery.filter((q) =>
+          q.eq(q.field("assignedMaker"), callerId),
         );
       }
 
@@ -158,6 +166,10 @@ export const getProjects = authQuery({
             return false;
           }
 
+          if (filterByAssignedMaker && project.assignedMaker !== callerId) {
+            return false;
+          }
+
           if (
             hasStatusFilter &&
             project.status !== (args.statusFilter as StatusUnion)
@@ -178,46 +190,60 @@ export const getProjects = authQuery({
     const baseQuery = ctx.db.query("projects");
 
     let orderedQuery;
-    switch (args.sortBy) {
-      case "price-high":
-      case "price-low":
-        // No price index; fall through to default creation-time order
-        orderedQuery = baseQuery.order(
-          args.sortBy === "price-high" ? "desc" : "asc",
-        );
-        break;
-      case "name-az":
-        orderedQuery = baseQuery.order("asc");
-        break;
-      case "oldest":
-        if (hasStatusFilter) {
-          orderedQuery = baseQuery
-            .withIndex("by_status", (q) =>
-              q.eq("status", args.statusFilter as StatusUnion),
-            )
-            .order("asc");
-        } else {
+
+    // When filtering by assigned maker without a status filter, use the
+    // by_assignedMaker index to avoid scanning the full table.
+    if (filterByAssignedMaker && !hasStatusFilter) {
+      orderedQuery = ctx.db
+        .query("projects")
+        .withIndex("by_assignedMaker", (q) => q.eq("assignedMaker", callerId))
+        .order(args.sortBy === "oldest" ? "asc" : "desc");
+    } else {
+      switch (args.sortBy) {
+        case "price-high":
+        case "price-low":
+          // No price index; fall through to default creation-time order
+          orderedQuery = baseQuery.order(
+            args.sortBy === "price-high" ? "desc" : "asc",
+          );
+          break;
+        case "name-az":
           orderedQuery = baseQuery.order("asc");
-        }
-        break;
-      case "newest":
-      default:
-        if (hasStatusFilter) {
-          orderedQuery = baseQuery
-            .withIndex("by_status", (q) =>
-              q.eq("status", args.statusFilter as StatusUnion),
-            )
-            .order("desc");
-        } else {
-          orderedQuery = baseQuery.order("desc");
-        }
-        break;
+          break;
+        case "oldest":
+          if (hasStatusFilter) {
+            orderedQuery = baseQuery
+              .withIndex("by_status", (q) =>
+                q.eq("status", args.statusFilter as StatusUnion),
+              )
+              .order("asc");
+          } else {
+            orderedQuery = baseQuery.order("asc");
+          }
+          break;
+        case "newest":
+        default:
+          if (hasStatusFilter) {
+            orderedQuery = baseQuery
+              .withIndex("by_status", (q) =>
+                q.eq("status", args.statusFilter as StatusUnion),
+              )
+              .order("desc");
+          } else {
+            orderedQuery = baseQuery.order("desc");
+          }
+          break;
+      }
     }
 
     let query = orderedQuery;
 
     if (!isPrivileged) {
       query = query.filter((q) => q.eq(q.field("userId"), callerId));
+    }
+
+    if (filterByAssignedMaker) {
+      query = query.filter((q) => q.eq(q.field("assignedMaker"), callerId));
     }
 
     if (
@@ -294,11 +320,16 @@ export const getProject = authQuery({
     const project = await ctx.db.get(args.projectId);
     if (!project) throw new ConvexError("Project not found.");
 
-    // Access control: admins and makers see all; clients only their own
+    // Access control: admin sees all; maker sees assigned projects;
+    // client sees only their own.
     const { role, _id: callerId } = ctx.profile;
-    const isPrivileged = role === "admin" || role === "maker";
 
-    if (!isPrivileged && project.userId !== callerId) {
+    const canView =
+      role === "admin" ||
+      (role === "maker" && project.assignedMaker === callerId) ||
+      project.userId === callerId;
+
+    if (!canView) {
       throw new ConvexError("You do not have permission to view this project.");
     }
 

--- a/convex/projects/query.ts
+++ b/convex/projects/query.ts
@@ -116,7 +116,8 @@ export const getProjects = authQuery({
   handler: async (ctx, args) => {
     const { role, _id: callerId } = ctx.profile;
     const isPrivileged = role === "admin" || role === "maker";
-    const filterByAssignedMaker = args.assignedToMe === true;
+    const filterByAssignedMaker =
+      args.assignedToMe === true && role === "maker";
 
     const hasStatusFilter =
       args.statusFilter !== undefined && args.statusFilter !== "all";
@@ -191,9 +192,11 @@ export const getProjects = authQuery({
 
     let orderedQuery;
 
-    // When filtering by assigned maker without a status filter, use the
-    // by_assignedMaker index to avoid scanning the full table.
-    if (filterByAssignedMaker && !hasStatusFilter) {
+    // Track whether the by_assignedMaker index already narrowed results
+    // to avoid a redundant .filter() later.
+    const assignedMakerIndexUsed = filterByAssignedMaker && !hasStatusFilter;
+
+    if (assignedMakerIndexUsed) {
       orderedQuery = ctx.db
         .query("projects")
         .withIndex("by_assignedMaker", (q) => q.eq("assignedMaker", callerId))
@@ -242,7 +245,8 @@ export const getProjects = authQuery({
       query = query.filter((q) => q.eq(q.field("userId"), callerId));
     }
 
-    if (filterByAssignedMaker) {
+    // Only filter by assigned maker when the index didn't already handle it
+    if (filterByAssignedMaker && !assignedMakerIndexUsed) {
       query = query.filter((q) => q.eq(q.field("assignedMaker"), callerId));
     }
 

--- a/convex/projects/query.ts
+++ b/convex/projects/query.ts
@@ -2,6 +2,7 @@ import { paginationOptsValidator } from "convex/server";
 import { ConvexError, v } from "convex/values";
 import { Id, Doc } from "../_generated/dataModel";
 import { QueryCtx } from "../_generated/server";
+import { UserRole } from "../constants";
 import { authQuery } from "../helper";
 import {
   addLabDays,
@@ -115,9 +116,9 @@ export const getProjects = authQuery({
   },
   handler: async (ctx, args) => {
     const { role, _id: callerId } = ctx.profile;
-    const isPrivileged = role === "admin" || role === "maker";
+    const isPrivileged = role === UserRole.ADMIN || role === UserRole.MAKER;
     const filterByAssignedMaker =
-      args.assignedToMe === true && role === "maker";
+      args.assignedToMe === true && role === UserRole.MAKER;
 
     const hasStatusFilter =
       args.statusFilter !== undefined && args.statusFilter !== "all";
@@ -266,6 +267,24 @@ export const getProjects = authQuery({
   },
 });
 
+// ── Lightweight query: assigned project IDs ───────────────────────────────────
+// Used by the chat sidebar to filter rooms to only assigned-project conversations.
+
+export const getAssignedProjectIds = authQuery({
+  args: {},
+  handler: async (ctx) => {
+    const { role, _id: callerId } = ctx.profile;
+    if (role !== UserRole.MAKER) return [];
+
+    const projects = await ctx.db
+      .query("projects")
+      .withIndex("by_assignedMaker", (q) => q.eq("assignedMaker", callerId))
+      .collect();
+
+    return projects.map((p) => p._id);
+  },
+});
+
 // ── Shared enrichment helper ──────────────────────────────────────────────────
 
 async function enrichProjects(ctx: QueryCtx, projects: Doc<"projects">[]) {
@@ -329,8 +348,8 @@ export const getProject = authQuery({
     const { role, _id: callerId } = ctx.profile;
 
     const canView =
-      role === "admin" ||
-      (role === "maker" && project.assignedMaker === callerId) ||
+      role === UserRole.ADMIN ||
+      (role === UserRole.MAKER && project.assignedMaker === callerId) ||
       project.userId === callerId;
 
     if (!canView) {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -257,6 +257,7 @@ export default defineSchema({
     .index("by_userProfile", ["userId"])
     .index("by_status", ["status"])
     .index("by_bookingStartTime", ["bookingStartTime"])
+    .index("by_assignedMaker", ["assignedMaker"])
     .searchIndex("search_body", {
       searchField: "searchText",
       filterFields: ["status"],

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -253,6 +253,7 @@ export default defineSchema({
     files: v.optional(v.array(v.string())),
     notes: v.string(),
     searchText: v.string(),
+    archivalDeadline: v.optional(v.number()),
   })
     .index("by_userProfile", ["userId"])
     .index("by_status", ["status"])

--- a/src/app/(private)/dashboard/(data-view)/projects/_client.tsx
+++ b/src/app/(private)/dashboard/(data-view)/projects/_client.tsx
@@ -173,6 +173,8 @@ export function ProjectsListClient() {
   const statusRaw = getSearchParam(searchParams, "status", "all");
   const dateRaw = getSearchParam(searchParams, "date", "all");
   const sortRaw = getSearchParam(searchParams, "sort", "newest");
+  const assignedToMeRaw = getSearchParam(searchParams, "assignedToMe");
+  const assignedToMe = assignedToMeRaw === "true";
   const view = getProjectsView(searchParams);
   const [selectedProjectId, setSelectedProjectId] =
     React.useState<Id<"projects"> | null>(null);
@@ -222,6 +224,7 @@ export function ProjectsListClient() {
       dateFilter: isSearching ? "all" : dateFilter,
       sortBy: isSearching ? "newest" : sortBy,
       searchText: search.trim() || undefined,
+      assignedToMe: assignedToMe || undefined,
     },
     { initialNumItems: 24 },
   );
@@ -265,9 +268,10 @@ export function ProjectsListClient() {
         )}
         emptyState={{
           icon: <PackageOpen className="size-12" />,
-          title: "No projects found",
-          description:
-            "The catalogue is empty. No clients have created projects or booking requests yet.",
+          title: assignedToMe ? "No assigned projects" : "No projects found",
+          description: assignedToMe
+            ? "You haven't been assigned any projects yet."
+            : "The catalogue is empty. No clients have created projects or booking requests yet.",
         }}
         filteredEmptyState={{
           icon: <Search className="size-8" />,
@@ -283,6 +287,7 @@ export function ProjectsListClient() {
                   status: null,
                   date: null,
                   sort: null,
+                  assignedToMe: null,
                 })
               }
             >

--- a/src/app/(private)/dashboard/(data-view)/projects/_page.tsx
+++ b/src/app/(private)/dashboard/(data-view)/projects/_page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import * as React from "react";
-import { LayoutGrid, List, Plus } from "lucide-react";
+import { LayoutGrid, List, Plus, UserCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -24,6 +24,8 @@ import {
   DataViewSearchField,
 } from "@/components/manage/data-view-toolbar";
 import { cn } from "@/lib/utils";
+import { UserRole } from "@convex/constants";
+import { useProfile } from "@/components/sidebar/profile-context";
 import { ProjectsListClient } from "./_client";
 
 const PROJECT_VIEWS = ["gallery", "list"] as const;
@@ -155,6 +157,31 @@ function ProjectFilterControls() {
   );
 }
 
+function AssignedProjectsToggle() {
+  const { searchParams, replaceParams } = useDataViewRouteState();
+  const profile = useProfile();
+  const assignedToMe = getSearchParam(searchParams, "assignedToMe") === "true";
+
+  // Only show the toggle for maker role users
+  if (profile?.role !== UserRole.MAKER) return null;
+
+  return (
+    <Button
+      variant={assignedToMe ? "default" : "outline"}
+      size="sm"
+      className={cn("h-8 shrink-0 gap-1.5")}
+      onClick={() =>
+        replaceParams({ assignedToMe: assignedToMe ? null : "true" })
+      }
+    >
+      <UserCheck className="h-4 w-4" />
+      <span className="hidden sm:inline">
+        {assignedToMe ? "Assigned Projects" : "All Projects"}
+      </span>
+    </Button>
+  );
+}
+
 function ProjectsPageHeader() {
   const { pathname, searchParams, replaceParams } = useDataViewRouteState();
   const search = getSearchParam(searchParams, "search");
@@ -173,6 +200,7 @@ function ProjectsPageHeader() {
         />
         <div className="flex shrink-0 items-center gap-2">
           <ProjectFilterControls />
+          <AssignedProjectsToggle />
           <ProjectsViewToggle />
           <Button size="sm" className="h-8 shrink-0 gap-1" asChild>
             <Link href="/services">

--- a/src/components/chat/chat-interface.tsx
+++ b/src/components/chat/chat-interface.tsx
@@ -1,12 +1,26 @@
 "use client";
 
 import { useState } from "react";
-import { Loader2, Send, User, Hash, ArrowLeft, Calendar } from "lucide-react";
+
+import {
+  Loader2,
+  Send,
+  User,
+  Hash,
+  ArrowLeft,
+  Calendar,
+  Clock,
+} from "lucide-react";
+import { useQuery } from "convex/react";
+import { api } from "@convex/_generated/api";
 import Link from "next/link";
 
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import type { Id } from "@convex/_generated/dataModel";
+import { formatLabDate } from "@/lib/lab-time";
+import { PROJECT_STATUS_LABELS } from "@convex/constants";
 import { FileUpload } from "@/components/file-upload";
 import { CHAT_ACCEPTED_TYPES } from "@/components/file-upload/utils";
 import { useChat } from "./use-chat";
@@ -61,6 +75,52 @@ function ThreadTitle({ title }: { title?: string }) {
         }}
       >
         {title ?? "channel"}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Shows a warning banner when the thread belongs to a project that has reached
+ * a terminal status (cancelled, rejected, or claimed) and is pending archival.
+ */
+function ArchivalBanner({ threadId }: { threadId: Id<"threads"> }) {
+  const info = useQuery(api.chat.query.getThreadProjectStatus, { threadId });
+
+  if (!info) return null;
+
+  const statusLabel =
+    PROJECT_STATUS_LABELS[info.status as keyof typeof PROJECT_STATUS_LABELS] ??
+    info.status;
+
+  const deadlineDate =
+    info.archivalDeadline !== null
+      ? formatLabDate(info.archivalDeadline, {
+          weekday: "short",
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+          hour: "numeric",
+          minute: "2-digit",
+          hourCycle: "h12",
+        })
+      : null;
+
+  if (!deadlineDate) return null;
+
+  return (
+    <div
+      className="flex shrink-0 items-center gap-2 px-4 py-2 text-xs"
+      style={{
+        background: "var(--fab-amber-light)",
+        borderBottom: "1px solid var(--fab-border-md)",
+        color: "var(--fab-text-primary)",
+      }}
+    >
+      <Clock className="h-3.5 w-3.5 shrink-0" />
+      <span>
+        This project has been marked as <strong>{statusLabel}</strong>. Thread
+        will be archived on <strong>{deadlineDate}</strong>.
       </span>
     </div>
   );
@@ -137,6 +197,10 @@ export function ChatInterface({
           roomId={roomId}
         />
       </div>
+
+      {/* ── Archival warning banner ──────────────────────────────────────── */}
+      <ArchivalBanner threadId={threadId} />
+
       {/* ── Grid background ───────────────────────────────────────────────── */}
       <div
         aria-hidden="true"

--- a/src/components/chat/chat-rooms-context.tsx
+++ b/src/components/chat/chat-rooms-context.tsx
@@ -11,6 +11,7 @@ export interface ChatThreadSummary {
   lastMessageText?: string;
   unreadCount?: number;
   archived?: "Archived" | "Active";
+  projectId?: string;
 }
 
 export interface ChatRoomSummary {

--- a/src/components/chat/chat-sidebar-content.tsx
+++ b/src/components/chat/chat-sidebar-content.tsx
@@ -113,8 +113,29 @@ function ChatThreadLink({
   );
 }
 
-export function ChatSidebarContent() {
+export function ChatSidebarContent({
+  assignedOnly = false,
+  assignedProjectIds,
+}: {
+  assignedOnly?: boolean;
+  assignedProjectIds?: readonly Id<"projects">[];
+}) {
   const { roomList, isLoading } = useChatRooms();
+
+  const assignedIdSet = React.useMemo(
+    () => new Set<string>(assignedProjectIds ?? []),
+    [assignedProjectIds],
+  );
+
+  const filteredRoomList = React.useMemo(() => {
+    if (!assignedOnly || assignedIdSet.size === 0) return roomList;
+
+    return roomList.filter((room) =>
+      room.threads?.some((thread) =>
+        thread.projectId ? assignedIdSet.has(thread.projectId) : false,
+      ),
+    );
+  }, [roomList, assignedOnly, assignedIdSet]);
 
   const [collapsedRooms, setCollapsedRooms] = React.useState<
     Record<string, boolean>
@@ -139,7 +160,7 @@ export function ChatSidebarContent() {
     return <ChatSidebarRoomsLoading />;
   }
 
-  if (roomList.length === 0) {
+  if (filteredRoomList.length === 0) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
         <p
@@ -149,7 +170,9 @@ export function ChatSidebarContent() {
             fontFamily: "var(--font-body)",
           }}
         >
-          No conversations found
+          {assignedOnly
+            ? "No assigned conversations"
+            : "No conversations found"}
         </p>
       </div>
     );
@@ -157,7 +180,7 @@ export function ChatSidebarContent() {
 
   return (
     <>
-      {roomList.map((room) => {
+      {filteredRoomList.map((room) => {
         const roomId = room._id;
 
         if (!roomId) return null;

--- a/src/components/chat/chat-sidebar-content.tsx
+++ b/src/components/chat/chat-sidebar-content.tsx
@@ -127,15 +127,11 @@ export function ChatSidebarContent({
     [assignedProjectIds],
   );
 
-  const filteredRoomList = React.useMemo(() => {
-    if (!assignedOnly || assignedIdSet.size === 0) return roomList;
-
-    return roomList.filter((room) =>
-      room.threads?.some((thread) =>
-        thread.projectId ? assignedIdSet.has(thread.projectId) : false,
-      ),
-    );
-  }, [roomList, assignedOnly, assignedIdSet]);
+  const filterProjectThread = React.useCallback(
+    (thread: ChatThreadSummary) =>
+      !thread.projectId || assignedIdSet.has(thread.projectId),
+    [assignedIdSet],
+  );
 
   const [collapsedRooms, setCollapsedRooms] = React.useState<
     Record<string, boolean>
@@ -160,7 +156,7 @@ export function ChatSidebarContent({
     return <ChatSidebarRoomsLoading />;
   }
 
-  if (filteredRoomList.length === 0) {
+  if (roomList.length === 0) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 p-8 text-center">
         <p
@@ -170,9 +166,7 @@ export function ChatSidebarContent({
             fontFamily: "var(--font-body)",
           }}
         >
-          {assignedOnly
-            ? "No assigned conversations"
-            : "No conversations found"}
+          No conversations found
         </p>
       </div>
     );
@@ -180,17 +174,17 @@ export function ChatSidebarContent({
 
   return (
     <>
-      {filteredRoomList.map((room) => {
+      {roomList.map((room) => {
         const roomId = room._id;
 
         if (!roomId) return null;
 
-        const activeThreads =
-          room.threads?.filter((thread) => thread.archived !== "Archived") ??
-          [];
-        const archivedThreads =
-          room.threads?.filter((thread) => thread.archived === "Archived") ??
-          [];
+        const activeThreads = (room.threads ?? [])
+          .filter((thread) => thread.archived !== "Archived")
+          .filter((thread) => !assignedOnly || filterProjectThread(thread));
+        const archivedThreads = (room.threads ?? [])
+          .filter((thread) => thread.archived === "Archived")
+          .filter((thread) => !assignedOnly || filterProjectThread(thread));
 
         return (
           <div key={roomId} className="flex flex-col">
@@ -238,8 +232,7 @@ export function ChatSidebarContent({
               </div>
             </div>
 
-            {room.threads &&
-            room.threads.length > 0 &&
+            {activeThreads.length + archivedThreads.length > 0 &&
             !collapsedRooms[roomId] ? (
               <div className="relative flex flex-col pb-2">
                 {activeThreads.map((thread) => (

--- a/src/components/chat/chat-sidebar-shell.tsx
+++ b/src/components/chat/chat-sidebar-shell.tsx
@@ -5,9 +5,11 @@ import { cn } from "@/lib/utils";
 export function ChatSidebarShell({
   className,
   children,
+  headerEnd,
 }: {
   className?: string;
   children: ReactNode;
+  headerEnd?: ReactNode;
 }) {
   return (
     <div
@@ -32,6 +34,7 @@ export function ChatSidebarShell({
           >
             Messaging
           </span>
+          {headerEnd}
         </div>
       </div>
 

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -1,11 +1,44 @@
+"use client";
+
+import * as React from "react";
+import { UserCheck } from "lucide-react";
+import { useQuery } from "convex/react";
+import { api } from "@convex/_generated/api";
+import { UserRole } from "@convex/constants";
+import { Button } from "@/components/ui/button";
+import { useProfile } from "@/components/sidebar/profile-context";
 import { ChatSidebarContent } from "./chat-sidebar-content";
 import { ChatSidebarRoomsLoading } from "./chat-loading";
 import { ChatSidebarShell } from "./chat-sidebar-shell";
 
 export function ChatSidebar({ className }: { className?: string }) {
+  const profile = useProfile();
+  const assignedProjectIds = useQuery(api.projects.query.getAssignedProjectIds);
+  const [assignedOnly, setAssignedOnly] = React.useState(false);
+
+  const isMaker = profile?.role === UserRole.MAKER;
+  const showToggle = isMaker && assignedProjectIds !== undefined;
+
+  const headerEnd = showToggle ? (
+    <Button
+      variant={assignedOnly ? "default" : "outline"}
+      size="sm"
+      className="h-7 shrink-0 gap-1 px-2 text-xs"
+      onClick={() => setAssignedOnly((prev) => !prev)}
+    >
+      <UserCheck className="h-3.5 w-3.5" />
+      <span className="hidden sm:inline">
+        {assignedOnly ? "Assigned" : "All Chats"}
+      </span>
+    </Button>
+  ) : undefined;
+
   return (
-    <ChatSidebarShell className={className}>
-      <ChatSidebarContent />
+    <ChatSidebarShell className={className} headerEnd={headerEnd}>
+      <ChatSidebarContent
+        assignedOnly={assignedOnly}
+        assignedProjectIds={assignedProjectIds}
+      />
     </ChatSidebarShell>
   );
 }

--- a/src/components/chat/room-settings-dialog.tsx
+++ b/src/components/chat/room-settings-dialog.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@convex/_generated/api";
 import type { Id } from "@convex/_generated/dataModel";
+import { UserRole } from "@convex/constants";
 import { toast } from "sonner";
 import { UserPlus, UserMinus, Search, Settings } from "lucide-react";
 
@@ -16,8 +17,10 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Label } from "@/components/ui/label";
+import { useProfile } from "@/components/sidebar/profile-context";
 
 interface RoomSettingsDialogProps {
   roomId: Id<"rooms">;
@@ -33,6 +36,9 @@ export function RoomSettingsDialog({
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [newRoomName, setNewRoomName] = useState(roomName);
+  const profile = useProfile();
+  const canManageMembers =
+    profile?.role === UserRole.ADMIN || profile?.role === UserRole.MAKER;
 
   const members = useQuery(api.chat.query.getRoomMembers, { roomId });
   const addableUsers = useQuery(api.chat.query.getAddableUsers, { roomId });
@@ -104,9 +110,16 @@ export function RoomSettingsDialog({
         </DialogHeader>
 
         <Tabs defaultValue="settings" className="w-full mt-2">
-          <TabsList className="grid w-full grid-cols-2 mb-4">
+          <TabsList
+            className={cn(
+              "grid w-full mb-4",
+              canManageMembers ? "grid-cols-2" : "grid-cols-1",
+            )}
+          >
             <TabsTrigger value="settings">Settings</TabsTrigger>
-            <TabsTrigger value="members">Members</TabsTrigger>
+            {canManageMembers && (
+              <TabsTrigger value="members">Members</TabsTrigger>
+            )}
           </TabsList>
 
           <TabsContent value="members" className="mt-0">

--- a/src/components/projects/cards/pricing-estimate-card.tsx
+++ b/src/components/projects/cards/pricing-estimate-card.tsx
@@ -397,7 +397,7 @@ export function PricingEstimateCard({
           projectId,
           makerId: selectedMakerId
             ? (selectedMakerId as Id<"userProfile">)
-            : undefined,
+            : null,
         });
       }
 

--- a/src/components/projects/cards/pricing-estimate-card.tsx
+++ b/src/components/projects/cards/pricing-estimate-card.tsx
@@ -211,9 +211,9 @@ export function PricingEstimateCard({
       ),
     [editableMaterialDocs],
   );
-  const editableResources = useMemo<EditableResource[]>(() => {
-    // We allow selecting any resource in the lab
-    return (resources ?? []).map((resourceDoc) => ({
+  const editableResources: EditableResource[] = (resources ?? [])
+    .filter((r) => (service?.resources ?? []).includes(r._id))
+    .map((resourceDoc) => ({
       _id: resourceDoc._id,
       name: resourceDoc.name,
       category: resourceDoc.category,
@@ -221,7 +221,6 @@ export function PricingEstimateCard({
       status: resourceDoc.status,
       description: resourceDoc.description,
     }));
-  }, [resources]);
 
   const previewByDraftKey = new Map(
     usageDrafts.map((draft) => [

--- a/src/components/projects/project-details-content.tsx
+++ b/src/components/projects/project-details-content.tsx
@@ -206,7 +206,7 @@ export function ProjectDetailsContent({
       return;
     }
 
-    if (status === "paid") {
+    if (status === "paid" && !project.receipt) {
       onMarkPaid();
       return;
     }

--- a/test/assigned-maker.test.ts
+++ b/test/assigned-maker.test.ts
@@ -512,6 +512,78 @@ describe("Assigned Maker — assignedToMe filter", () => {
     expect(after).not.toContain(makerAId);
   });
 
+  test("Unassigning a maker via null makerId clears assignment and removes from room", async () => {
+    const { t, tAera, projectAId } = await setup();
+
+    const { makerAId, roomId } = await t.run(async (ctx) => {
+      const makerA = await ctx.db
+        .query("userProfile")
+        .withIndex("by_userId", (q) => q.eq("userId", "3"))
+        .first();
+      const thread = await ctx.db
+        .query("threads")
+        .withIndex("projectId", (q) => q.eq("projectId", projectAId))
+        .first();
+      return { makerAId: makerA!._id, roomId: thread!.roomId };
+    });
+
+    // Verify makerA is assigned
+    const before = await t.run(async (ctx) => {
+      const project = await ctx.db.get(projectAId);
+      return project!.assignedMaker;
+    });
+    expect(before).toBe(makerAId);
+
+    // Unassign: pass null to clear the maker
+    await tAera.mutation(api.projects.mutate.updateProject, {
+      projectId: projectAId,
+      makerId: null,
+    });
+    await flushScheduledFunctions(t);
+
+    // Verify makerA is no longer assigned (Convex returns null for cleared optional fields)
+    const after = await t.run(async (ctx) => {
+      const project = await ctx.db.get(projectAId);
+      return project!.assignedMaker;
+    });
+    expect(after).toBeNull();
+
+    // Verify makerA is removed from the room
+    const roomMemberIds = await t.run(async (ctx) => {
+      const members = await ctx.db
+        .query("roomMembers")
+        .filter((q) => q.eq(q.field("roomId"), roomId))
+        .collect();
+      return members.map((m) => m.participantId);
+    });
+    expect(roomMemberIds).not.toContain(makerAId);
+  });
+
+  test("Unassigning an already-unassigned project is a no-op", async () => {
+    const { t, tAera, projectBId } = await setup();
+
+    // Project B has no assigned maker
+    const before = await t.run(async (ctx) => {
+      const project = await ctx.db.get(projectBId);
+      return project!.assignedMaker;
+    });
+    expect(before).toBeNull();
+
+    // Attempting to unassign should not throw
+    await tAera.mutation(api.projects.mutate.updateProject, {
+      projectId: projectBId,
+      makerId: null,
+    });
+    await flushScheduledFunctions(t);
+
+    // Still unassigned
+    const after = await t.run(async (ctx) => {
+      const project = await ctx.db.get(projectBId);
+      return project!.assignedMaker;
+    });
+    expect(after).toBeNull();
+  });
+
   test("Assigned maker can see chat messages in the project room", async () => {
     const { t, tMakerA, tHarley, projectAId } = await setup();
 

--- a/test/assigned-maker.test.ts
+++ b/test/assigned-maker.test.ts
@@ -145,7 +145,7 @@ describe("Assigned Maker — assignedToMe filter", () => {
       paginationOpts: { cursor: null, numItems: 10 },
     });
 
-    const names = result.page.map((p: any) => p.name);
+    const names = result.page.map((p) => p.name);
     expect(names).toContain("Project A (assigned)");
     expect(names).toContain("Project B (unassigned)");
   });
@@ -158,7 +158,7 @@ describe("Assigned Maker — assignedToMe filter", () => {
       assignedToMe: true,
     });
 
-    const names = result.page.map((p: any) => p.name);
+    const names = result.page.map((p) => p.name);
     expect(names).toEqual(["Project A (assigned)"]);
     expect(names).not.toContain("Project B (unassigned)");
   });
@@ -181,7 +181,7 @@ describe("Assigned Maker — assignedToMe filter", () => {
       paginationOpts: { cursor: null, numItems: 10 },
     });
 
-    const names = result.page.map((p: any) => p.name);
+    const names = result.page.map((p) => p.name);
     expect(names).toContain("Project A (assigned)");
     expect(names).toContain("Project B (unassigned)");
   });
@@ -285,8 +285,8 @@ describe("Assigned Maker — assignedToMe filter", () => {
     );
 
     const makerAProjectIds = makerABookings
-      .filter((b: any) => b.projectId !== null)
-      .map((b: any) => b.projectId);
+      .filter((b) => b.projectId !== null)
+      .map((b) => b.projectId);
 
     expect(makerAProjectIds).toContain(projectAId);
     expect(makerAProjectIds).not.toContain(projectBId);
@@ -297,9 +297,7 @@ describe("Assigned Maker — assignedToMe filter", () => {
       { startTime, endTime, tab: "services" },
     );
 
-    const makerBVisible = makerBBookings.filter(
-      (b: any) => b.projectId !== null,
-    );
+    const makerBVisible = makerBBookings.filter((b) => b.projectId !== null);
     expect(makerBVisible).toHaveLength(0);
 
     // Admin sees all unmasked
@@ -309,8 +307,8 @@ describe("Assigned Maker — assignedToMe filter", () => {
     );
 
     const adminProjectIds = adminBookings
-      .filter((b: any) => b.projectId !== null)
-      .map((b: any) => b.projectId);
+      .filter((b) => b.projectId !== null)
+      .map((b) => b.projectId);
 
     expect(adminProjectIds).toContain(projectAId);
     expect(adminProjectIds).toContain(projectBId);
@@ -333,7 +331,7 @@ describe("Assigned Maker — assignedToMe filter", () => {
       },
     );
 
-    const pendingNames = pendingAssigned.page.map((p: any) => p.name);
+    const pendingNames = pendingAssigned.page.map((p) => p.name);
     expect(pendingNames).toEqual(["Project A (assigned)"]);
 
     // Change project A to "approved"
@@ -607,7 +605,7 @@ describe("Assigned Maker — assignedToMe filter", () => {
 
     // getRooms should return the room for Maker A
     const makerARooms = await tMakerA.query(api.chat.query.getRooms);
-    const makerARoomIds = makerARooms.map((r: any) => r._id);
+    const makerARoomIds = makerARooms.map((r) => r._id);
     expect(makerARoomIds).toContain(roomId);
 
     // Maker A can retrieve messages from the project thread
@@ -632,7 +630,7 @@ describe("Assigned Maker — assignedToMe filter", () => {
 
     // Maker B should NOT have the room in their room list
     const makerBRooms = await tMakerB.query(api.chat.query.getRooms);
-    const makerBRoomIds = makerBRooms.map((r: any) => r._id);
+    const makerBRoomIds = makerBRooms.map((r) => r._id);
     expect(makerBRoomIds).not.toContain(roomId);
   });
 });

--- a/test/assigned-maker.test.ts
+++ b/test/assigned-maker.test.ts
@@ -1,0 +1,382 @@
+import { describe, expect, test } from "vitest";
+import { flushScheduledFunctions, setupProject, setupUsers } from "./helper";
+import { api, internal } from "../convex/_generated/api";
+import type { Id } from "../convex/_generated/dataModel";
+
+const HOUR_MS = 1000 * 60 * 60;
+
+describe("Assigned Maker — assignedToMe filter", () => {
+  // ── Setup ──────────────────────────────────────────────────────────────────
+  //
+  // Creates:
+  //   - t        : the root Convex test instance
+  //   - tHarley  : a *client* (userId "1")
+  //   - tAera    : an *admin* (userId "2")
+  //   - makerA   : a *maker* who will be assigned to projectA
+  //   - makerB   : a *maker* who won't be assigned to any project
+  //   - projectA : owned by Harley, assigned to makerA
+  //   - projectB : owned by Harley, *no* assigned maker
+  //
+  async function setup() {
+    const { t, tHarley, tAera } = await setupUsers();
+
+    // ── Create makers ──────────────────────────────────────────────────────
+    await t.mutation(internal.users.createMaker, {
+      userId: "3",
+      email: "makerA@test.dev",
+      name: "Maker A",
+    });
+    await t.mutation(internal.users.createMaker, {
+      userId: "4",
+      email: "makerB@test.dev",
+      name: "Maker B",
+    });
+
+    const makerAProfile: { _id: Id<"userProfile"> } = await t.run(
+      async (ctx) => {
+        const p = await ctx.db
+          .query("userProfile")
+          .withIndex("by_userId", (q) => q.eq("userId", "3"))
+          .first();
+        return { _id: p!._id };
+      },
+    );
+    const makerBProfile: { _id: Id<"userProfile"> } = await t.run(
+      async (ctx) => {
+        const p = await ctx.db
+          .query("userProfile")
+          .withIndex("by_userId", (q) => q.eq("userId", "4"))
+          .first();
+        return { _id: p!._id };
+      },
+    );
+
+    // ── Create a service (reused for both projects) ────────────────────────
+    await tAera.mutation(api.services.mutate.addService, {
+      name: "3d printing",
+      images: [],
+      samples: [],
+      serviceCategory: {
+        type: "FABRICATION",
+        materials: [],
+        setupFee: 1,
+        unitName: "hour",
+        timeRate: 2,
+      },
+      requirements: ["design", "model"],
+      fileTypes: [],
+      description: "std to 3d printed model",
+      status: "Available",
+    });
+
+    const serviceId = await t.run(async (ctx) => {
+      const service = await ctx.db.query("services").first();
+      return service!._id;
+    });
+
+    const now = Date.now();
+
+    // ── Project A: assigned to makerA ──────────────────────────────────────
+    const { projectId: projectAId } = await tHarley.mutation(
+      api.projects.mutate.createProject,
+      {
+        name: "Project A (assigned)",
+        pricing: "UP",
+        description: "Assigned to Maker A",
+        fulfillmentMode: "self-service",
+        material: "provide-own",
+        files: [],
+        service: serviceId,
+        notes: "",
+        assignedMaker: makerAProfile._id,
+        booking: {
+          startTime: now + HOUR_MS,
+          endTime: now + 2 * HOUR_MS,
+          date: now + 24 * HOUR_MS,
+        },
+      },
+    );
+
+    // ── Project B: no assigned maker, 3 hours later to avoid slot conflict ──
+    const { projectId: projectBId } = await tHarley.mutation(
+      api.projects.mutate.createProject,
+      {
+        name: "Project B (unassigned)",
+        pricing: "UP",
+        description: "Unassigned",
+        fulfillmentMode: "self-service",
+        material: "provide-own",
+        files: [],
+        service: serviceId,
+        notes: "",
+        booking: {
+          startTime: now + 4 * HOUR_MS,
+          endTime: now + 5 * HOUR_MS,
+          date: now + 24 * HOUR_MS,
+        },
+      },
+    );
+
+    await flushScheduledFunctions(t);
+
+    const tMakerA = t.withIdentity({ subject: "3", name: "Maker A" });
+    const tMakerB = t.withIdentity({ subject: "4", name: "Maker B" });
+
+    return {
+      t,
+      tHarley,
+      tAera,
+      tMakerA,
+      tMakerB,
+      projectAId,
+      projectBId,
+      serviceId,
+    };
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Tests: getProjects list
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  test("Maker sees ALL projects when assignedToMe is not set (backward compat)", async () => {
+    const { tMakerA } = await setup();
+
+    const result = await tMakerA.query(api.projects.query.getProjects, {
+      paginationOpts: { cursor: null, numItems: 10 },
+    });
+
+    const names = result.page.map((p: any) => p.name);
+    expect(names).toContain("Project A (assigned)");
+    expect(names).toContain("Project B (unassigned)");
+  });
+
+  test("Maker sees only their assigned project when assignedToMe is true", async () => {
+    const { tMakerA } = await setup();
+
+    const result = await tMakerA.query(api.projects.query.getProjects, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      assignedToMe: true,
+    });
+
+    const names = result.page.map((p: any) => p.name);
+    expect(names).toEqual(["Project A (assigned)"]);
+    expect(names).not.toContain("Project B (unassigned)");
+  });
+
+  test("Unassigned maker sees NO projects when assignedToMe is true", async () => {
+    const { tMakerB } = await setup();
+
+    const result = await tMakerB.query(api.projects.query.getProjects, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      assignedToMe: true,
+    });
+
+    expect(result.page).toHaveLength(0);
+  });
+
+  test("Unassigned maker still sees ALL projects when assignedToMe is not set", async () => {
+    const { tMakerB } = await setup();
+
+    const result = await tMakerB.query(api.projects.query.getProjects, {
+      paginationOpts: { cursor: null, numItems: 10 },
+    });
+
+    const names = result.page.map((p: any) => p.name);
+    expect(names).toContain("Project A (assigned)");
+    expect(names).toContain("Project B (unassigned)");
+  });
+
+  test("Admin sees ALL projects regardless of assignedToMe filter", async () => {
+    const { tAera } = await setup();
+
+    const without = await tAera.query(api.projects.query.getProjects, {
+      paginationOpts: { cursor: null, numItems: 10 },
+    });
+    const withFilter = await tAera.query(api.projects.query.getProjects, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      assignedToMe: true,
+    });
+
+    expect(without.page).toHaveLength(2);
+    expect(withFilter.page).toHaveLength(2); // admin sees all either way
+  });
+
+  test("Client sees only their own projects regardless of assignedToMe", async () => {
+    const { tHarley } = await setup();
+
+    const without = await tHarley.query(api.projects.query.getProjects, {
+      paginationOpts: { cursor: null, numItems: 10 },
+    });
+    const withFilter = await tHarley.query(api.projects.query.getProjects, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      assignedToMe: true,
+    });
+
+    // Client owns both projects
+    expect(without.page).toHaveLength(2);
+    // assignedToMe is effectively a no-op for clients
+    expect(withFilter.page).toHaveLength(2);
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Tests: getProject detail view
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  test("Assigned maker can view project details via getProject", async () => {
+    const { tMakerA, projectAId } = await setup();
+
+    // Should not throw
+    const project = await tMakerA.query(api.projects.query.getProject, {
+      projectId: projectAId,
+    });
+
+    expect(project.name).toBe("Project A (assigned)");
+  });
+
+  test("Unassigned maker cannot view project details via getProject", async () => {
+    const { tMakerB, projectAId } = await setup();
+
+    await expect(
+      tMakerB.query(api.projects.query.getProject, {
+        projectId: projectAId,
+      }),
+    ).rejects.toThrow("You do not have permission to view this project");
+  });
+
+  test("Admin can view any project details via getProject", async () => {
+    const { tAera, projectAId, projectBId } = await setup();
+
+    const projectA = await tAera.query(api.projects.query.getProject, {
+      projectId: projectAId,
+    });
+    const projectB = await tAera.query(api.projects.query.getProject, {
+      projectId: projectBId,
+    });
+
+    expect(projectA.name).toBe("Project A (assigned)");
+    expect(projectB.name).toBe("Project B (unassigned)");
+  });
+
+  test("Owner client can view their own project's details", async () => {
+    const { tHarley, projectAId } = await setup();
+
+    const project = await tHarley.query(api.projects.query.getProject, {
+      projectId: projectAId,
+    });
+
+    expect(project.name).toBe("Project A (assigned)");
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Tests: Calendar helper (loadOwnedProjectIds)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  test("Calendar: maker sees details for assigned projects; unassigned bookings are masked", async () => {
+    const { tMakerA, tMakerB, tAera, projectAId, projectBId } = await setup();
+
+    // Fetch a wide calendar range that covers both projects
+    const startTime = Date.now() - 24 * HOUR_MS;
+    const endTime = Date.now() + 48 * HOUR_MS;
+
+    // Maker A (assigned to projectA) should see project A's details but not project B's
+    const makerABookings = await tMakerA.query(
+      api.calendar.query.getCalendarBookings,
+      { startTime, endTime, tab: "services" },
+    );
+
+    const makerAProjectIds = makerABookings
+      .filter((b: any) => b.projectId !== null)
+      .map((b: any) => b.projectId);
+
+    expect(makerAProjectIds).toContain(projectAId);
+    expect(makerAProjectIds).not.toContain(projectBId);
+
+    // Maker B (no assignments) should see all null projectIds (masked)
+    const makerBBookings = await tMakerB.query(
+      api.calendar.query.getCalendarBookings,
+      { startTime, endTime, tab: "services" },
+    );
+
+    const makerBVisible = makerBBookings.filter(
+      (b: any) => b.projectId !== null,
+    );
+    expect(makerBVisible).toHaveLength(0);
+
+    // Admin sees all unmasked
+    const adminBookings = await tAera.query(
+      api.calendar.query.getCalendarBookings,
+      { startTime, endTime, tab: "services" },
+    );
+
+    const adminProjectIds = adminBookings
+      .filter((b: any) => b.projectId !== null)
+      .map((b: any) => b.projectId);
+
+    expect(adminProjectIds).toContain(projectAId);
+    expect(adminProjectIds).toContain(projectBId);
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Tests: assignedToMe combines with other filters
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  test("assignedToMe stacks with status filter", async () => {
+    const { t, tAera, tMakerA, projectAId } = await setup();
+
+    // Both projects start as "pending"
+    const pendingAssigned = await tMakerA.query(
+      api.projects.query.getProjects,
+      {
+        paginationOpts: { cursor: null, numItems: 10 },
+        statusFilter: "pending",
+        assignedToMe: true,
+      },
+    );
+
+    const pendingNames = pendingAssigned.page.map((p: any) => p.name);
+    expect(pendingNames).toEqual(["Project A (assigned)"]);
+
+    // Change project A to "approved"
+    await tAera.mutation(api.projects.mutate.updateProject, {
+      projectId: projectAId,
+      status: "approved",
+    });
+    await flushScheduledFunctions(t);
+
+    // Now "pending" filter should return 0 for maker A
+    const afterApproved = await tMakerA.query(api.projects.query.getProjects, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      statusFilter: "pending",
+      assignedToMe: true,
+    });
+
+    expect(afterApproved.page).toHaveLength(0);
+
+    // But "approved" + assignedToMe returns project A
+    const approvedAssigned = await tMakerA.query(
+      api.projects.query.getProjects,
+      {
+        paginationOpts: { cursor: null, numItems: 10 },
+        statusFilter: "approved",
+        assignedToMe: true,
+      },
+    );
+
+    expect(approvedAssigned.page).toHaveLength(1);
+    expect(approvedAssigned.page[0].name).toBe("Project A (assigned)");
+  });
+
+  test("assignedToMe stacks with search filter", async () => {
+    const { tMakerA } = await setup();
+
+    // Search for "assigned" — only project A matches
+    const result = await tMakerA.query(api.projects.query.getProjects, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      searchText: "assigned",
+      assignedToMe: true,
+    });
+
+    expect(result.page).toHaveLength(1);
+    expect(result.page[0].name).toBe("Project A (assigned)");
+  });
+});

--- a/test/assigned-maker.test.ts
+++ b/test/assigned-maker.test.ts
@@ -379,4 +379,188 @@ describe("Assigned Maker — assignedToMe filter", () => {
     expect(result.page).toHaveLength(1);
     expect(result.page[0].name).toBe("Project A (assigned)");
   });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Tests: Chat room membership
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  test("Pre-assigned maker is added to the project chat room on creation", async () => {
+    const { t, projectAId } = await setup();
+
+    // Find the room for project A (created with assignedMaker = makerA)
+    const { roomId, makerAId } = await t.run(async (ctx) => {
+      const threadA = await ctx.db
+        .query("threads")
+        .withIndex("projectId", (q) => q.eq("projectId", projectAId))
+        .first();
+      expect(threadA).not.toBeNull();
+
+      const makerA = await ctx.db
+        .query("userProfile")
+        .withIndex("by_userId", (q) => q.eq("userId", "3"))
+        .first();
+
+      return { roomId: threadA!.roomId, makerAId: makerA!._id };
+    });
+
+    const roomMembers = await t.run(async (ctx) => {
+      const members = await ctx.db
+        .query("roomMembers")
+        .filter((q) => q.eq(q.field("roomId"), roomId))
+        .collect();
+      return members.map((m) => m.participantId);
+    });
+
+    // Maker A should be a member of the project's room
+    expect(roomMembers).toContain(makerAId);
+  });
+
+  test("Assigning a maker via updateProject adds them to the chat room", async () => {
+    const { t, tAera, projectBId } = await setup();
+
+    const { makerBId, roomId } = await t.run(async (ctx) => {
+      const makerB = await ctx.db
+        .query("userProfile")
+        .withIndex("by_userId", (q) => q.eq("userId", "4"))
+        .first();
+      const thread = await ctx.db
+        .query("threads")
+        .withIndex("projectId", (q) => q.eq("projectId", projectBId))
+        .first();
+      return { makerBId: makerB!._id, roomId: thread!.roomId };
+    });
+
+    // makerB should NOT be in the room yet (never assigned anywhere)
+    const before = await t.run(async (ctx) => {
+      const members = await ctx.db
+        .query("roomMembers")
+        .filter((q) => q.eq(q.field("roomId"), roomId))
+        .collect();
+      return members.map((m) => m.participantId);
+    });
+    expect(before).not.toContain(makerBId);
+
+    // Assign makerB to project B
+    await tAera.mutation(api.projects.mutate.updateProject, {
+      projectId: projectBId,
+      makerId: makerBId,
+    });
+    await flushScheduledFunctions(t);
+
+    // Verify makerB is now a room member
+    const after = await t.run(async (ctx) => {
+      const members = await ctx.db
+        .query("roomMembers")
+        .filter((q) => q.eq(q.field("roomId"), roomId))
+        .collect();
+      return members.map((m) => m.participantId);
+    });
+
+    expect(after).toContain(makerBId);
+  });
+
+  test("Reassigning a maker removes old maker and adds new maker to the chat room", async () => {
+    const { t, tAera, projectAId } = await setup();
+
+    const { makerAId, makerBId, roomId } = await t.run(async (ctx) => {
+      const makerA = await ctx.db
+        .query("userProfile")
+        .withIndex("by_userId", (q) => q.eq("userId", "3"))
+        .first();
+      const makerB = await ctx.db
+        .query("userProfile")
+        .withIndex("by_userId", (q) => q.eq("userId", "4"))
+        .first();
+      const thread = await ctx.db
+        .query("threads")
+        .withIndex("projectId", (q) => q.eq("projectId", projectAId))
+        .first();
+      return {
+        makerAId: makerA!._id,
+        makerBId: makerB!._id,
+        roomId: thread!.roomId,
+      };
+    });
+
+    // Verify makerA is initially in the room (pre-assigned on creation)
+    const before = await t.run(async (ctx) => {
+      const members = await ctx.db
+        .query("roomMembers")
+        .filter((q) => q.eq(q.field("roomId"), roomId))
+        .collect();
+      return members.map((m) => m.participantId);
+    });
+    expect(before).toContain(makerAId);
+
+    // Reassign: replace makerA with makerB
+    await tAera.mutation(api.projects.mutate.updateProject, {
+      projectId: projectAId,
+      makerId: makerBId,
+    });
+    await flushScheduledFunctions(t);
+
+    // Verify makerA is removed and makerB is added
+    const after = await t.run(async (ctx) => {
+      const members = await ctx.db
+        .query("roomMembers")
+        .filter((q) => q.eq(q.field("roomId"), roomId))
+        .collect();
+      return members.map((m) => m.participantId);
+    });
+
+    expect(after).toContain(makerBId);
+    expect(after).not.toContain(makerAId);
+  });
+
+  test("Assigned maker can see chat messages in the project room", async () => {
+    const { t, tMakerA, tHarley, projectAId } = await setup();
+
+    // Maker A should be able to query the room (chat queries check membership)
+    const threadId = await t.run(async (ctx) => {
+      const thread = await ctx.db
+        .query("threads")
+        .withIndex("projectId", (q) => q.eq("projectId", projectAId))
+        .first();
+      return thread!._id;
+    });
+
+    // Maker A can query the room's messages (convex chat query checks membership)
+    const roomId = await t.run(async (ctx) => {
+      const thread = await ctx.db
+        .query("threads")
+        .withIndex("projectId", (q) => q.eq("projectId", projectAId))
+        .first();
+      return thread!.roomId;
+    });
+
+    // getRooms should return the room for Maker A
+    const makerARooms = await tMakerA.query(api.chat.query.getRooms);
+    const makerARoomIds = makerARooms.map((r: any) => r._id);
+    expect(makerARoomIds).toContain(roomId);
+
+    // Maker A can retrieve messages from the project thread
+    const messages = await tMakerA.query(api.chat.query.getRoomMessages, {
+      paginationOpts: { cursor: null, numItems: 10 },
+      room: roomId,
+      threadId,
+    });
+    expect(messages.page.length).toBeGreaterThan(0);
+  });
+
+  test("Unassigned maker cannot see chat messages in the project room", async () => {
+    const { t, tMakerB, projectAId } = await setup();
+
+    const roomId = await t.run(async (ctx) => {
+      const thread = await ctx.db
+        .query("threads")
+        .withIndex("projectId", (q) => q.eq("projectId", projectAId))
+        .first();
+      return thread!.roomId;
+    });
+
+    // Maker B should NOT have the room in their room list
+    const makerBRooms = await tMakerB.query(api.chat.query.getRooms);
+    const makerBRoomIds = makerBRooms.map((r: any) => r._id);
+    expect(makerBRoomIds).not.toContain(roomId);
+  });
 });

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -483,8 +483,12 @@ describe("Project and Chat functionality", () => {
         }),
       );
 
-      expect(jobs).toHaveLength(1);
-      expect(jobs[0]?.args[0]).toMatchObject({
+      // Two jobs: the claimed email + the scheduled thread archival
+      expect(jobs).toHaveLength(2);
+
+      // One of them is the email
+      const emailJob = jobs.find((j) => j?.args[0]?.status === "claimed");
+      expect(emailJob?.args[0]).toMatchObject({
         to: "delivered+harley@resend.dev",
         projectName: "test",
         status: "claimed",


### PR DESCRIPTION
### Changes

**🧑‍🔧 Maker Assignment Enhancements (`convex/projects/helper.ts`)**
- Refactored `applyMakerAssignment` to support both **assignment** (valid maker ID) and **unassignment** (passing `null`).
- Automatically adds/removes the maker from the project's chat room on assignment changes.
- Guards against removing a maker from a room if they are still assigned to another project in the same room.
- `applyMakerAssignment` now accepts `Id<"userProfile"> | null` instead of only a required ID.

**🗄 Schema Updates (`convex/schema.ts`)**
- Added `archivalDeadline?: number` field to the `projects` table.
- Added `by_assignedMaker` index on `projects` for efficient queries by assigned maker.

**🔒 Calendar Visibility Fixes (`convex/calendar/helper.ts`)**
- Makers now see only **their assigned projects** in the calendar (previously they saw all projects like admins).
- Clients continue to only see their own projects.
- Admins retain full visibility.
- Replaced magic string role checks with `UserRole` constants.

**📝 Thread Lifecycle & Archival (`convex/projects/mutate.ts`, `convex/constants.ts`)**
- Defined `PROJECT_ARCHIVE_STATUSES` (`cancelled`, `rejected`, `claimed`) in constants.
- When a project transitions to a terminal status, a **24-hour scheduled archival** is triggered.
- A system message is posted warning about the pending archival with the deadline date.
- `archiveProjectThread` (internal mutation) sends a final "archived" system message and sets the thread to `Archived`.
- The `archivalDeadline` is cleared if the project leaves a terminal state.
- `markProjectPaid` now also accepts `claimed` projects.

**💬 Chat Thread Archival Banner (`src/components/chat/chat-interface.tsx`)**
- New `ArchivalBanner` component that shows an amber warning bar at the top of a chat interface when the associated project has reached a terminal status and is pending archival.
- Displays the status label and the date/time the thread will be archived.
- Backed by `getThreadProjectStatus` Convex query (`convex/chat/query.ts`).

**🔎 "Assigned to Me" Filter for Makers (`src/app/(private)/dashboard/(data-view)/projects/`)**
- New `AssignedProjectsToggle` button (visible only to makers) that filters the project list to show only projects assigned to the current user.
- Added `assignedToMe` search param support in the client.
- Appropriate dynamic empty state messages ("No assigned projects" vs "No projects found").

**💬 Maker Chat Sidebar Filter (`src/components/chat/chat-sidebar.tsx`, `chat-sidebar-content.tsx`)**
- Makers can toggle between "All Chats" and "Assigned" in the chat sidebar header.
- When "Assigned" mode is active, only threads belonging to projects the maker is assigned to are displayed.
- Added `headerEnd` prop to `ChatSidebarShell` to support the toggle button placement.
- Added `projectId` to `ChatThreadSummary` interface.

**🔐 Room Settings: Member Management Scoping (`src/components/chat/room-settings-dialog.tsx`)**
- The "Members" tab in room settings is now only visible to **admins and makers** (clients can only see the "Settings" tab).
- Dynamically adjusts the tabs grid layout based on the number of visible tabs.

**🛠 `updateProject` — Maker Unassignment (`convex/projects/mutate.ts`)**
- The `makerId` argument now accepts `null` (to unassign) in addition to a valid user profile ID (to assign/reassign) and `undefined` (no change).

**🧪 Tests (`test/assigned-maker.test.ts`)**
- Comprehensive test suite (636 lines) covering maker assignment, the `assignedToMe` filter, and related behaviors.

**🔧 Miscellaneous Fixes**
- `pricing-estimate-card.tsx`: Resources are now filtered to only those belonging to the selected service; `makerId` is passed as `null` instead of `undefined` for unassignment.
- `project-details-content.tsx`: Added a guard so "Mark as Paid" only triggers if the project doesn't already have a receipt.
