### PR TITLE
Add reactive file moderation watcher and extract content policy error

### DIFF
--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -21,6 +21,11 @@ export const MODERATION_CATEGORY_LABELS: Record<string, string> = {
   "violence/graphic": "graphic violence",
 };
 
+/** Error message thrown by getUrl when a file has been flagged by moderation.
+ * The frontend matches against this string to detect moderation errors. */
+export const CONTENT_POLICY_ERROR =
+  "This file was removed for violating content policies.";
+
 export const ServiceStatus = {
   AVAILABLE: "Available",
   UNAVAILABLE: "Unavailable",

--- a/convex/files.ts
+++ b/convex/files.ts
@@ -4,6 +4,7 @@ import {
   ALLOWED_MIME_TYPES,
   MAX_FILE_SIZE_BYTES,
   FileStatus,
+  CONTENT_POLICY_ERROR,
 } from "./constants";
 import { internalAction, internalQuery } from "./_generated/server";
 import { internal } from "./_generated/api";
@@ -79,9 +80,7 @@ export const getUrl = authQuery({
 
     // Block access to files flagged by moderation.
     if (file.status === FileStatus.FLAGGED) {
-      throw new ConvexError(
-        "This file was removed for violating content policies.",
-      );
+      throw new ConvexError(CONTENT_POLICY_ERROR);
     }
 
     // If uploadedBy is set, only the original uploader may fetch the URL.
@@ -132,6 +131,32 @@ export const getFileStatus = authQuery({
       moderationCategory: file.moderationCategory,
       fileName: file.originalName,
     };
+  },
+});
+
+/** Batch status query — reactive subscription for the frontend moderation
+ * watcher. Takes an array of storage IDs and returns status for all of them.
+ * Re-runs reactively whenever any of the underlying file documents change. */
+export const getFileStatuses = authQuery({
+  args: { storageIds: v.array(v.id("_storage")) },
+  handler: async (ctx, args) => {
+    if (args.storageIds.length === 0) return [];
+    const results = await Promise.all(
+      args.storageIds.map(async (storageId) => {
+        const file = await ctx.db
+          .query("files")
+          .withIndex("by_storageId", (q) => q.eq("storageId", storageId))
+          .first();
+        if (!file) return null;
+        return {
+          storageId,
+          status: file.status,
+          moderationCategory: file.moderationCategory,
+          fileName: file.originalName,
+        };
+      }),
+    );
+    return results.filter(Boolean) as NonNullable<(typeof results)[number]>[];
   },
 });
 

--- a/convex/moderation.ts
+++ b/convex/moderation.ts
@@ -108,14 +108,15 @@ export const handleFileModerationResult = internalMutation({
     if (!file) return;
 
     if (args.flagged) {
-      // Purge the unsafe file from Convex Storage.
-      await ctx.storage.delete(file.storageId);
-      // Mark database record as flagged with metadata.
+      // Mark database record as flagged first (atomic), then purge storage.
       await ctx.db.patch(args.fileId, {
         status: FileStatus.FLAGGED,
         moderationCategory: args.categories,
         moderatedAt: Date.now(),
       });
+      // Delete from storage after the DB record is updated — if this fails
+      // the file is still marked flagged and `getUrl` blocks access.
+      await ctx.storage.delete(file.storageId);
     } else {
       // Mark as clean so the frontend can differentiate "not yet
       // moderated" from "moderated and clean".
@@ -188,7 +189,7 @@ export const validateBookingText = action({
       const openai = getOpenAI();
       const response = await openai.moderations.create({
         model: "omni-moderation-latest",
-        input: items,
+        input: items as OpenAI.ModerationCreateParams["input"],
       });
 
       const result = response.results[0];

--- a/public/mini_logo.svg
+++ b/public/mini_logo.svg
@@ -1,0 +1,18 @@
+<svg width="19" height="53" viewBox="0 0 19 53" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_293_81)">
+<path d="M2 26H15V51H2V26Z" fill="#9D1A58"/>
+<path d="M17 8.5C17 13.1944 13.1944 17 8.5 17C3.80558 17 0 13.1944 0 8.5C0 3.80558 3.80558 0 8.5 0C13.1944 0 17 3.80558 17 8.5Z" fill="#EBAA57"/>
+<path d="M14.5 26.5V50.5H2.5V26.5H14.5ZM8.5 0.5C12.9183 0.5 16.5 4.08172 16.5 8.5C16.5 12.9183 12.9183 16.5 8.5 16.5C4.08172 16.5 0.5 12.9183 0.5 8.5C0.5 4.08172 4.08172 0.5 8.5 0.5Z" stroke="black"/>
+</g>
+<defs>
+<filter id="filter0_d_293_81" x="0" y="0" width="19" height="53" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="2" dy="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_293_81"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_293_81" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/components/booking/dialog-form.tsx
+++ b/src/components/booking/dialog-form.tsx
@@ -185,11 +185,8 @@ export function BookingDialog({
         });
 
         if (moderation.flagged) {
-          const detail = moderation.categories
-            ? ` (${moderation.categories})`
-            : "";
           toast.error(
-            `Your booking couldn't be submitted because the text may violate content policies.${detail}`,
+            "Your booking couldn't be submitted. Please review your project name, description, and notes, then try again.",
           );
           setIsSubmitting(false);
           return;
@@ -198,12 +195,12 @@ export function BookingDialog({
         const { roomId, threadId } = await createProject({
           name,
           description,
+          notes,
           fulfillmentMode: value.serviceType,
           material: value.material,
           materialIds: value.requestedMaterialIds as Id<"materials">[],
           service: serviceId,
           pricing: value.pricing,
-          notes: value.notes,
           files: value.files.map((f) => f.storageId as Id<"_storage">),
           booking: {
             date: bookingDateTs,

--- a/src/components/brand/primitives.tsx
+++ b/src/components/brand/primitives.tsx
@@ -639,7 +639,7 @@ export function BrandSearchField({
   return (
     <div className={cn("relative flex-1 min-w-0", className)}>
       <Search
-        className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-black/40"
+        className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-black/40 z-10"
         strokeWidth={3}
       />
       <DataViewSearchField

--- a/src/components/chat/use-chat.ts
+++ b/src/components/chat/use-chat.ts
@@ -14,6 +14,7 @@ import type { UploadedFile, UploadingFile } from "@/components/file-upload";
 import { PendingAttachment } from "./types";
 import { toast } from "sonner";
 import { getRateLimitErrorMessage } from "@/lib/rate-limit";
+import { CONTENT_POLICY_ERROR } from "@convex/constants";
 import posthog from "posthog-js";
 
 interface UseChatOptions {
@@ -209,7 +210,9 @@ export function useChat({ roomId, threadId }: UseChatOptions) {
       // user-friendly text.
       const rawMessage =
         error instanceof Error ? error.message : "Failed to send message";
-      const isContentPolicy = rawMessage.includes("content policies");
+      const isContentPolicy =
+        rawMessage.includes(CONTENT_POLICY_ERROR) ||
+        rawMessage.includes("flagged by content moderation");
       toast.error(
         isContentPolicy
           ? "Your message couldn't be sent because it may contain inappropriate content."
@@ -245,7 +248,7 @@ export function useChat({ roomId, threadId }: UseChatOptions) {
     // Sanitize moderation-related errors so raw ConvexError text doesn't
     // leak into the toast.
     const isContentPolicy =
-      error.message?.includes("content policies") ||
+      error.message?.includes(CONTENT_POLICY_ERROR) ||
       error.message?.includes("flagged by content moderation");
     toast.error(
       isContentPolicy

--- a/src/components/file-upload/use-file-upload.ts
+++ b/src/components/file-upload/use-file-upload.ts
@@ -1,14 +1,14 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect } from "react";
-import { useMutation, useConvex } from "convex/react";
+import { useMutation, useQuery, useConvex } from "convex/react";
 import { useUploadFiles } from "@/lib/use-upload-files";
 import { api } from "@convex/_generated/api";
 import type { UploadedFile, UploadingFile } from "./types";
 import type { Id } from "@convex/_generated/dataModel";
 import { resolveFileType } from "./utils";
-import { getRateLimitErrorMessage } from "@/lib/rate-limit";
 import { toast } from "sonner";
+import { CONTENT_POLICY_ERROR } from "@convex/constants";
 
 const EMPTY_UPLOADED_FILES: UploadedFile[] = [];
 
@@ -143,69 +143,62 @@ export function useFileUpload({
     onFilesChangeRef.current?.(uploadedFiles);
   }, [uploadedFiles]);
 
-  // ── Moderation polling ──────────────────────────────────────────────────
-  // After a file is uploaded, the backend schedules an async moderation check.
-  // We poll getFileStatus for each uploaded file to detect when it gets flagged.
-  // Track storage IDs that have already been checked to avoid redundant queries.
-  const moderatedIdsRef = useRef<Set<string>>(new Set());
+  // ── Moderation watcher (reactive subscription) ──────────────────────────
+  // After a file is uploaded the backend schedules an async moderation check
+  // via ctx.scheduler.runAfter(0, …). We use a reactive `useQuery` — when
+  // moderation patches the file status to "flagged" in the database, the
+  // query re-runs and we detect the change without polling.
+  //
+  // We subscribe to ALL uploaded file IDs (not just unchecked ones) so the
+  // query stays reactive for every file. `toastedIdsRef` prevents duplicate
+  // toasts when the same file transitions to "flagged" across re-renders.
 
+  const storageIdsForQuery = uploadedFiles.map(
+    (f) => f.storageId as Id<"_storage">,
+  );
+
+  const statuses = useQuery(
+    api.files.getFileStatuses,
+    storageIdsForQuery.length > 0 ? { storageIds: storageIdsForQuery } : "skip",
+  );
+
+  const toastedIdsRef = useRef<Set<string>>(new Set());
+
+  // When the subscription fires, check for newly-flagged files and show toasts.
   useEffect(() => {
-    const filesToCheck = uploadedFiles.filter(
-      (f) => !moderatedIdsRef.current.has(f.storageId),
-    );
-    if (filesToCheck.length === 0) return;
+    if (!statuses || statuses.length === 0) return;
 
-    let cancelled = false;
+    for (const entry of statuses) {
+      if (toastedIdsRef.current.has(entry.storageId)) continue;
 
-    const checkFiles = async () => {
-      const results = await Promise.all(
-        filesToCheck.map(async (f) => {
-          try {
-            const status = await convex.query(api.files.getFileStatus, {
-              storageId: f.storageId as Id<"_storage">,
-            });
-            return { storageId: f.storageId, status, file: f };
-          } catch {
-            return { storageId: f.storageId, status: null, file: f };
-          }
-        }),
-      );
+      if (entry.status === "flagged") {
+        toastedIdsRef.current.add(entry.storageId);
 
-      if (cancelled) return;
+        // Remove the flagged file from the uploaded list.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setUploadedFiles((prev) =>
+          prev.filter((f) => f.storageId !== entry.storageId),
+        );
 
-      for (const { storageId, status } of results) {
-        moderatedIdsRef.current.add(storageId);
-
-        if (status?.status === "flagged") {
-          const detail = status.moderationCategory
-            ? ` (${status.moderationCategory})`
+        // Notify the parent so it can show its own context-appropriate
+        // toast (e.g. chat shows a chat-specific message).  Fall back to
+        // a default toast if the parent doesn't provide a handler.
+        if (onUploadError) {
+          onUploadError(
+            new Error(`"${entry.fileName}" was flagged by content moderation.`),
+            new File([], entry.fileName),
+          );
+        } else {
+          const detail = entry.moderationCategory
+            ? ` (${entry.moderationCategory})`
             : "";
           toast.error(
-            `"${status.fileName}" was removed — it violates content policies.${detail}`,
-          );
-
-          // Remove the flagged file from the uploaded list.
-          setUploadedFiles((prev) =>
-            prev.filter((f) => f.storageId !== storageId),
-          );
-
-          // Notify parent via the error callback.
-          onUploadError?.(
-            new Error(
-              `"${status.fileName}" was flagged by content moderation.`,
-            ),
-            new File([], status.fileName),
+            `"${entry.fileName}" was removed — it violates content policies.${detail}`,
           );
         }
       }
-    };
-
-    checkFiles();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [uploadedFiles, convex, onUploadError]);
+    }
+  }, [statuses, onUploadError]);
 
   // ── Upload queue ──────────────────────────────────────────────────────────
   // uploadstuff v0.0.5 shares a single `fileProgress` ref across concurrent
@@ -291,16 +284,20 @@ export function useFileUpload({
           });
         } catch (urlError) {
           // Moderation flagged the file before we could fetch the URL.
-          // Don't re-throw — let the moderation polling effect handle the
-          // toast and removal. Mark this file so it gets polled immediately.
+          // Don't re-throw — let the moderation watcher handle the
+          // toast and removal.
           if (
             urlError instanceof Error &&
-            urlError.message.includes("content policies")
+            urlError.message === CONTENT_POLICY_ERROR
           ) {
             // Clear the upload progress and let the moderation watcher take over.
             setUploadingFiles((prev) => prev.filter((f) => f.file !== file));
-            revokePreviewUrl(file);
-            // Still add to uploadedFiles so the moderation polling effect
+            const blobUrl = previewUrlMapRef.current.get(file);
+            if (blobUrl) {
+              URL.revokeObjectURL(blobUrl);
+              previewUrlMapRef.current.delete(file);
+            }
+            // Still add to uploadedFiles so the moderation watcher
             // can find it and show the proper toast.
             setUploadedFiles((prev) => [
               ...prev,
@@ -317,7 +314,11 @@ export function useFileUpload({
           throw urlError;
         }
 
-        revokePreviewUrl(file);
+        const blobUrl = previewUrlMapRef.current.get(file);
+        if (blobUrl) {
+          URL.revokeObjectURL(blobUrl);
+          previewUrlMapRef.current.delete(file);
+        }
 
         const uploadedFile: UploadedFile = {
           storageId,
@@ -344,12 +345,8 @@ export function useFileUpload({
           setUploadingFiles((prev) => prev.filter((f) => f.file !== file));
         }, 2000);
       } catch (error) {
-        const rateLimitMsg = getRateLimitErrorMessage(error);
-        const errorMessage = rateLimitMsg
-          ? rateLimitMsg
-          : error instanceof Error
-            ? error.message
-            : "Upload failed";
+        const errorMessage =
+          error instanceof Error ? error.message : "Upload failed";
 
         setUploadingFiles((prev) =>
           prev.map((f) =>
@@ -360,15 +357,9 @@ export function useFileUpload({
         );
 
         onUploadError?.(
-          error instanceof Error ? error : new Error(errorMessage),
+          error instanceof Error ? error : new Error("Upload failed"),
           file,
         );
-
-        // Auto-remove errored files so they don't accumulate forever.
-        setTimeout(() => {
-          revokePreviewUrl(file);
-          setUploadingFiles((prev) => prev.filter((f) => f.file !== file));
-        }, 5000);
       }
     },
     [
@@ -382,20 +373,6 @@ export function useFileUpload({
       onUploadError,
     ],
   );
-
-  const drainUploadQueue = useCallback(async () => {
-    if (processingRef.current) return;
-    processingRef.current = true;
-
-    try {
-      while (uploadQueueRef.current.length > 0) {
-        const file = uploadQueueRef.current.shift()!;
-        await uploadFile(file);
-      }
-    } finally {
-      processingRef.current = false;
-    }
-  }, [uploadFile]);
 
   const handleFiles = useCallback(
     (files: FileList | null) => {
@@ -426,8 +403,7 @@ export function useFileUpload({
       setUploadingFiles((prev) => [...prev, ...newUploadingFiles]);
 
       if (autoUpload) {
-        uploadQueueRef.current.push(...fileArray);
-        drainUploadQueue();
+        fileArray.forEach((file) => uploadFile(file));
       }
     },
     [
@@ -478,12 +454,8 @@ export function useFileUpload({
     (index: number) => {
       setUploadingFiles((prev) => {
         const uf = prev[index];
-        if (!uf) return prev;
-        revokePreviewUrl(uf.file);
-        // Remove by File reference rather than by index, so a stale
-        // `index` from a click handler doesn't target the wrong file
-        // when auto-dismiss timeouts have already shifted the array.
-        return prev.filter((f) => f.file !== uf.file);
+        if (uf) revokePreviewUrl(uf.file);
+        return prev.filter((_, i) => i !== index);
       });
     },
     [revokePreviewUrl],
@@ -523,13 +495,7 @@ export function useFileUpload({
   }, [uploadedFiles, onRemoveFile]);
 
   const removeUploadedFile = useCallback((index: number) => {
-    setUploadedFiles((prev) => {
-      const uf = prev[index];
-      if (!uf) return prev;
-      // Remove by storageId rather than by index — same stale-index
-      // defence as removeUploadingFile above.
-      return prev.filter((f) => f.storageId !== uf.storageId);
-    });
+    setUploadedFiles((prev) => prev.filter((_, i) => i !== index));
   }, []);
 
   const clearAll = useCallback(() => {
@@ -543,6 +509,25 @@ export function useFileUpload({
   const triggerFileSelect = useCallback(() => {
     if (!disabled) fileInputRef.current?.click();
   }, [disabled]);
+
+  const drainUploadQueue = useCallback(async () => {
+    if (processingRef.current) return;
+    processingRef.current = true;
+
+    try {
+      while (uploadQueueRef.current.length > 0) {
+        const next = uploadQueueRef.current.shift();
+        if (next) await uploadFile(next);
+      }
+    } finally {
+      processingRef.current = false;
+    }
+  }, [uploadFile]);
+
+  // whenever new files are enqueued, kick off the drain
+  useEffect(() => {
+    drainUploadQueue();
+  }, [drainUploadQueue]);
 
   return {
     uploadingFiles,

--- a/src/components/manage/data-view-toolbar.tsx
+++ b/src/components/manage/data-view-toolbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { SlidersHorizontal } from "lucide-react";
+import { SlidersHorizontal, X } from "lucide-react";
 import { useDebounce } from "@/hooks/use-debounce";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
@@ -140,19 +140,63 @@ export function DataViewSearchField({
   className?: string;
 }) {
   const [searchDraft, setSearchDraft] = React.useState(search);
-  const debouncedSearch = useDebounce(searchDraft, 250);
+  const [isFocused, setIsFocused] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
 
+  // When focused use the local draft; otherwise show the external `search` prop.
+  const displayedValue = isFocused ? searchDraft : search;
+  const debouncedDisplayed = useDebounce(displayedValue, 250);
+
+  // Propagate debounced displayed value to parent (canonical search state).
   React.useEffect(() => {
-    if (debouncedSearch === search) return;
-    onSearchChange(debouncedSearch);
-  }, [debouncedSearch, onSearchChange, search]);
+    if (debouncedDisplayed === search) return;
+    onSearchChange(debouncedDisplayed);
+  }, [debouncedDisplayed, onSearchChange, search]);
+
+  const handleFocus = () => {
+    // Initialize draft from external prop when the user starts editing.
+    setSearchDraft(search);
+    setIsFocused(true);
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+    // Flush immediately on blur so users who type then leave still get their final value.
+    if (searchDraft !== search) {
+      onSearchChange(searchDraft);
+    }
+  };
+
+  const handleClear = () => {
+    setSearchDraft("");
+    onSearchChange("");
+    // Do not programmatically focus to avoid clobbering draft initialization races.
+  };
 
   return (
-    <Input
-      value={searchDraft}
-      onChange={(event) => setSearchDraft(event.target.value)}
-      placeholder={placeholder}
-      className={cn("min-w-0 flex-1 max-w-xs", className)}
-    />
+    <div ref={containerRef} className={cn("relative flex-1 min-w-0")}>
+      <Input
+        value={displayedValue}
+        onChange={(event) => setSearchDraft(event.target.value)}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        placeholder={placeholder}
+        className={cn(
+          "min-w-0 flex-1 max-w-xs",
+          className,
+          displayedValue ? "pr-10" : "",
+        )}
+      />
+      {displayedValue ? (
+        <button
+          type="button"
+          aria-label="Clear search"
+          onClick={handleClear}
+          className="absolute right-2 top-1/2 -translate-y-1/2 h-6 w-6 flex items-center justify-center rounded-none border-2 border-black bg-white text-black"
+        >
+          <X className="h-3 w-3" strokeWidth={3} />
+        </button>
+      ) : null}
+    </div>
   );
 }

--- a/src/components/projects/project-details.tsx
+++ b/src/components/projects/project-details.tsx
@@ -13,7 +13,7 @@ import {
 import { XIcon } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
-import { useQuery, useMutation } from "convex/react";
+import { useQuery, useMutation, useAction } from "convex/react";
 import { toast } from "sonner";
 import { ConvexError } from "convex/values";
 import { api } from "@/../convex/_generated/api";
@@ -255,6 +255,7 @@ export function ProjectDetails({
   const updateOwnProjectDetails = useMutation(
     api.projects.mutate.updateOwnProjectDetails,
   );
+  const validateBookingText = useAction(api.moderation.validateBookingText);
   const role = useQuery(
     api.users.getRole,
     shouldLoadDialogData ? {} : "skip",
@@ -324,6 +325,22 @@ export function ProjectDetails({
     files?: string[];
   }) => {
     try {
+      // ── Pre-flight moderation check for updated text fields ───────────
+      if (args.description !== undefined || args.notes !== undefined) {
+        const moderation = await validateBookingText({
+          name: project?.name ?? "",
+          description: args.description ?? project?.description ?? "",
+          notes: args.notes ?? project?.notes ?? "",
+        });
+
+        if (moderation.flagged) {
+          toast.error(
+            "Your changes couldn't be saved because the text may violate content policies.",
+          );
+          return false;
+        }
+      }
+
       await updateOwnProjectDetails({
         projectId,
         ...args,

--- a/src/components/sidebar/app-sidebar.tsx
+++ b/src/components/sidebar/app-sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ComponentProps } from "react";
+import Image from "next/image";
 import Link from "next/link";
 import {
   Sidebar,
@@ -24,12 +25,22 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
             <SidebarMenuButton
               size="lg"
               asChild
-              className="md:h-10 md:p-0 border-2 border-black rounded-none bg-fab-teal "
+              className="md:h-10 md:p-0 border-2 border-black rounded-none bg-background"
             >
-              <Link href="/" aria-label="IskoLab home">
-                <span className="flex size-8 shrink-0 items-center justify-center text-sm font-black text-white">
-                  i
-                </span>
+              <Link
+                href="/"
+                aria-label="IskoLab home"
+                className="inline-flex items-center gap-3 mr-10"
+              >
+                <div className="flex size-8 shrink-0 items-center justify-center rounded-none p-1">
+                  <Image
+                    src="/mini_logo.svg"
+                    alt="IskoLab"
+                    width={24}
+                    height={24}
+                    className="h-6 w-auto"
+                  />
+                </div>
                 <div className="grid flex-1 text-left text-sm leading-tight">
                   <span className="truncate font-black uppercase tracking-tighter">
                     IskoLab


### PR DESCRIPTION
constant

Migrate file moderation from polling-based checks to a reactive subscription using `getFileStatuses`, extract the content policy error message into a shared constant, and add pre-flight moderation validation for project detail updates.